### PR TITLE
First pass at refactoring

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -26,23 +26,25 @@ def FilingStatus(MARS):
         sep = 1
 
     return sep
+
+
+@vectorize(['float64(float64, float64, float64'])
+def foreign_income_ded(e35300_0, e35600_0, e35910_0):
+    _feided = max(e35300_0, e35600_0 + e35910_0)  # Form 2555
     
+    return _feided
+
 
 def Adj():
     # Adjustments
-    global _feided
-    global c02900
-    _feided = np.maximum(e35300_0, e35600_0, + e35910_0)  # Form 2555
-
-    x03150 = e03150
-    c02900 = (x03150 + e03210 + e03600 + e03260 + e03270 + e03300
+    c02900 = (e03150 + e03210 + e03600 + e03260 + e03270 + e03300
               + e03400 + e03500 + e03280 + e03900 + e04000 + e03700
               + e03220 + e03230
               + e03240
               + e03290)
 
-    return DataFrame(data=np.column_stack((_feided, c02900)),
-                     columns=['_feided', 'c02900'])
+    return DataFrame(data=c02900, columns=['c02900'])
+
 
 def CapGains():
     # Capital Gains


### PR DESCRIPTION
@talumbau I know you said we should stave off the issue of global variables, but to be honest, I'm having a little trouble refactoring without a clear concept of variable sharing. On the one hand, numba very heavily favors writing a bunch of small functions each of which focuses on calculating (and returning) just one variable. On the other hand, we want every function to return a DataFrame because this seems to be the common currency we're operating with.

I think the most reasonable way to address this at this point is to have all the functions in `taxcalc.calculate` only return vectors, then modify `test.run` so that it a) selects the right variables as inputs to functions from `taxcalc.calculate` and b) converts all their outputs to DataFrames and incorporates them into the global namespace so that these outputs are accessible to any later computations, should they be required. It this way `test.run` (or an equivalent function) will _stitch together_ the results of running a lot of small numba-ized functions.

Thoughts?
@MattHJensen 
