### PR TITLE
specify mods via JSON

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -25,7 +25,13 @@ def update_calculator_from_module(calc, mod):
     calc.__dict__.update(calc_vals_overwrite)
 
 
-def calculator(data, **kwargs):
+def calculator(data, mods="", **kwargs):
+    if mods:
+        import json
+        dd = json.loads(mods)
+        dd = {k:np.array(v) for k,v in dd.items() if type(v) == list}
+        kwargs.update(dd)
+
     calc = Calculator(data)
     if kwargs:
         calc.__dict__.update(kwargs)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -94,6 +94,15 @@ def test_make_Calculator_mods():
     assert all(calc2._amex == np.array([4000]))
 
 
+def test_make_Calculator_json():
+    user_mods = '{ "_aged": [[1500], [1200]] }'
+    calc2 = calculator(tax_dta, mods=user_mods, _amex=np.array([4000]))
+    update_calculator_from_module(calc2, constants)
+    update_globals_from_calculator(calc2)
+    assert all(calc2._amex == np.array([4000]))
+    assert all(calc2._aged == np.array([[1500], [1200]]))
+
+
 
 class TaxCalcError(Exception):
     '''I've stripped this down to a simple extension of the basic Exception for


### PR DESCRIPTION
This is necessary to translate modifications of the standard tax model into actual changes in a Calculator object. User interaction with the webapp (i.e filling in the data fields) will create a JSON string. This string will be passed to the `calculator` function to modify the Calculator.

Example JSON:

```
    {
        "_aged" : [[1500], [1200]]
    }
```

Use in code:

```
    >>>calc = calculator(user_json)
    >>>calc._aged
    array([[1500],
       [1200]])
```

cc @theofanislekkas @MattHJensen 
