### PR TITLE
add relative import

### DIFF
--- a/timer/timed_calculate.py
+++ b/timer/timed_calculate.py
@@ -8,7 +8,7 @@ raw calculation time can be printed by calling 'print(main_timer)' at the end of
 
 from taxcalc.calculate import *
 from taxcalc.puf import *
-from timer_utils import cumulative_timer, time_this
+from .timer_utils import cumulative_timer, time_this
 
 
 main_timer = cumulative_timer("All Fuctions, no CSV calls, no concat calls")


### PR DESCRIPTION
Needed to add this so one could do as follows:
1. start at top of repo
2. modify `test.py` as described in first part of timer/README.md
3. run `python test.py`

Without this PR, you get an import error.
