### PR TITLE
Remove obsolete .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-taxcalc/_version.py export-subst


### PR DESCRIPTION
Should have been removed when `taxcalc/_version.py` file was removed.