### PR TITLE
 Use new taxsim_emulation.json "reform" file in validation work

### DIFF
--- a/taxcalc/validation/taxsim/a17.taxdiffs-expect
+++ b/taxcalc/validation/taxsim/a17.taxdiffs-expect
@@ -1,0 +1,4 @@
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 19    941    941     -0.01 [185]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27     26     26     -0.01 [2594]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28     68     68     -0.01 [1064]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4    102    102     -0.01 [874]

--- a/taxcalc/validation/taxsim/taxcalc.sh
+++ b/taxcalc/validation/taxsim/taxcalc.sh
@@ -31,13 +31,14 @@ L=${LYY_FN:0:1}
 YY=${LYY_FN:1:2}
 python prepare_taxcalc_input.py $LYY_FN $LYY_FN.csv
 # ... calculate Tax-Calculator output
-tc $LYY_FN.csv 20$YY --dump
+tc $LYY_FN.csv 20$YY --reform taxsim_emulation.json --dump
+mv $LYY_FN-$YY-#-taxsim_emulation-#.csv $LYY_FN.out.csv
+rm -f $LYY_FN-$YY-#-taxsim_emulation-#-doc.text
 # ... convert Tax-Calculator output to Internet-TAXSIM-27-format
-python process_taxcalc_output.py $LYY_FN-$YY-#-#-#.csv $LYY_FN.out-taxcalc
+python process_taxcalc_output.py $LYY_FN.out.csv $LYY_FN.out-taxcalc
 # ... delete intermediate input and output files if not saving files
-rm -f $LYY_FN-$YY-#-#-#-doc.text
 if [[ $SAVE == false ]]; then
     rm -f $LYY_FN.csv
-    rm -f $LYY_FN-$YY-#-#-#.csv
+    rm -f $LYY_FN.out.csv
 fi
 exit 0

--- a/taxcalc/validation/taxsim/taxsim_emulation.json
+++ b/taxcalc/validation/taxsim/taxsim_emulation.json
@@ -1,0 +1,9 @@
+// JSON "reform" file that specifies changes in current-law policy that
+// are required to make Tax-Calculator work like TAXSIM-27.
+{
+    "policy": {
+
+        "_AMT_child_em_c_age": {"2013": [24]}
+
+    }
+}

--- a/taxcalc/validation/taxsim/test.sh
+++ b/taxcalc/validation/taxsim/test.sh
@@ -46,14 +46,16 @@ fi
 # check for difference between LYY.taxdiffs-actual and LYY.taxdiffs-expect
 diff --brief $LYY.taxdiffs-actual $LYY.taxdiffs-expect
 RC=$?
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
 if [[ $RC -ne 0 ]]; then
     MSG="DIFF $LYY"
-    RED=$(tput setaf 1)
-    BOLD=$(tput bold)
-    NORMAL=$(tput sgr0)
     printf "$BOLD$RED$MSG$NORMAL\n"
 else
-    printf "SAME $LYY\n"
+    MSG="SAME $LYY"
+    printf "$BOLD$GREEN$MSG$NORMAL\n"
     if [[ "$SAVE" == "" ]] ; then
         rm -f $LYY.taxdiffs-actual
     fi


### PR DESCRIPTION
The pull request adds the use of a JSON reform file that makes Tax-Calculator use the same policy parameters as used by [TAXSIM-27](https://users.nber.org/~taxsim/taxsim27/).