### PR TITLE
Add validation results for the b17 assumption set

### DIFF
--- a/taxcalc/validation/taxsim/README.md
+++ b/taxcalc/validation/taxsim/README.md
@@ -21,6 +21,13 @@ The following results are for INPUT files containing 100,000
 randomly-generated filing units for a given year.  The random
 sampling is such that a different sample is drawn for each year.
 
+In order to handle known differences in assumptions between the two
+models, we use the `taxsim_emulation.json` "reform" file to make
+Tax-Calculator operate like TAXSIM-27.  See the
+[`taxsim_emulation.json`
+file](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/validation/taxsim/taxsim_emulation.json)
+for details.
+
 In the following results, when we say "same results" we mean the all
 the output variables being compared have differences of no larger than
 one cent.
@@ -32,4 +39,11 @@ Validation Results
 that specify the first twelve of the TAXSIM-27 input variables, which
 include demographic variables and labor income, but set to zero all
 the TAXSIM-27 input variables numbered from 13 through 27.  Only the
-2017 results are being saved for future validation testing.
+2017 results are being saved for future validation testing. (This is
+the a17 assumption set.)
+
+**2018-12-08** : Same results for a 2017 INPUT file that specifies
+interest income plus the first twelve of the TAXSIM-27 input
+variables, which include demographic variables and labor income, but
+set to zero all the other TAXSIM-27 input variables. (This is the b17
+assumption set.)

--- a/taxcalc/validation/taxsim/b17.taxdiffs-expect
+++ b/taxcalc/validation/taxsim/b17.taxdiffs-expect
@@ -1,0 +1,4 @@
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 19   1014   1014     -0.01 [874]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27     21     21     -0.01 [3212]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28     74     74     -0.01 [2859]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4     18     18     -0.01 [874]

--- a/taxcalc/validation/taxsim/taxsim_emulation.json
+++ b/taxcalc/validation/taxsim/taxsim_emulation.json
@@ -3,7 +3,9 @@
 {
     "policy": {
 
-        "_AMT_child_em_c_age": {"2013": [24]}
+        "_AMT_child_em_c_age": {"2013": [24]},
+
+        "_EITC_excess_InvestIncome_rt": {"2013": [1.0]}
 
     }
 }

--- a/taxcalc/validation/taxsim/taxsim_emulation.json
+++ b/taxcalc/validation/taxsim/taxsim_emulation.json
@@ -1,5 +1,32 @@
 // JSON "reform" file that specifies changes in current-law policy that
 // are required to make Tax-Calculator work like TAXSIM-27.
+//
+// (1) _AMT_child_em_c_age = 24 (rather than 18)
+//     Whether to set this parameter to 18 or 24 is arbitary because
+//     neither model has enough information to apply correctly the child
+//     AMT exemption rules.  Information on full-time student status and
+//     whether taxpayers provide more than half of their support are required
+//     to apply the rules correctly.  Tax-Calculator makes the arbitrary
+//     assumption that only those under 18 are required to use the child
+//     AMT exemption rules, while TAXSIM-27 makes the arbitrary assumption
+//     that all those under 24 are required to use the child AMT exemption.
+//     [This change was introduced for assumption set b and higher.]
+//
+// (2) _EITC_excess_InvestIncome_rt = 1.0 (rather than 9e99)
+//     The rate at which the EITC amount is reduced per dollar of investment
+//     income in excess of the EITC investment income ceiling is infinity under
+//     current law (that is, any investment income in excess of the ceiling
+//     causes EITC ineligibility).  However, TAXSIM-27 assumes it is one, so
+//     that the EITC amount is reduced a dollar for each dollar of excess
+//     investment income.  This difference in the parameter value leads to
+//     many EITC differences in the randomly-generated validation samples,
+//     with some of the differences being in the thousands of dollars.  This
+//     non-current-law assumption in TAXSIM-27 is presumably made to reduce
+//     the magnitude of model-calculated marginal tax rates with respect to
+//     investment income in cases where the marginal increase in investment
+//     income takes a filing unit above the ceiling.
+//     [This change was introduced for assumption set b and higher.]
+//
 {
     "policy": {
 


### PR DESCRIPTION
The b17 sample is the same as the a17 sample except for the addition of randomly-generated interest income.
For details on the validation results read [this summary](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/validation/taxsim/README.md#validation-of-tax-calculator-against-internet-taxsim-version-27).