### PR TITLE
Expand scope of validation tests

### DIFF
--- a/taxcalc/validation/taxsim/README.md
+++ b/taxcalc/validation/taxsim/README.md
@@ -18,8 +18,12 @@ Finally, these two OUTPUT files are compared using the `taxdiffs.tcl`
 script.  See the `test.sh` scripts in this directory for more details.
 
 The following results are for INPUT files containing 100,000
-randomly-generated filing units for a given year.  The random
-sampling is such that a different sample is drawn for each year.
+randomly-generated filing units for a given year.  The random sampling
+is such that a different sample is drawn for each year.  In each INPUT
+file three state-related variables are set to zero for every filing
+unit, one variable specifies the year, and another specifies an filing
+unit id, which leaves twenty-two input variables that are set to
+randomly-generated values.
 
 In order to handle known differences in assumptions between the two
 models, we use the `taxsim_emulation.json` "reform" file to make

--- a/taxcalc/validation/taxsim/README.md
+++ b/taxcalc/validation/taxsim/README.md
@@ -28,22 +28,26 @@ Tax-Calculator operate like TAXSIM-27.  See the
 file](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/validation/taxsim/taxsim_emulation.json)
 for details.
 
-In the following results, when we say "same results" we mean the all
-the output variables being compared have differences of no larger than
-one cent.
+In the following results, when we say "same results" we mean that the
+federal individual income tax liabilities and payroll tax liabilities
+being compared have differences of no larger than one cent.
 
 Validation Results
 ------------------
 
-**2018-12-07** : Same results for INPUT files for 2013 through 2017
-that specify the first twelve of the TAXSIM-27 input variables, which
+**2018-12-10** : Same results for a 2017 INPUT file that specifies
+the first twelve of the TAXSIM-27 input variables, which
 include demographic variables and labor income, but set to zero all
-the TAXSIM-27 input variables numbered from 13 through 27.  Only the
-2017 results are being saved for future validation testing. (This is
+the TAXSIM-27 input variables numbered from 13 through 27. (This is
 the a17 assumption set.)
 
-**2018-12-08** : Same results for a 2017 INPUT file that specifies
-interest income plus the first twelve of the TAXSIM-27 input
-variables, which include demographic variables and labor income, but
-set to zero all the other TAXSIM-27 input variables. (This is the b17
-assumption set.)
+**2018-12-10** : Same results for a 2017 INPUT file that specifies the
+first twenty-one of the TAXSIM-27 input variables, which include
+demographic variables, labor income, capital income, and
+federally-taxable benefits, but set to zero all the other six
+TAXSIM-27 input variables.  Two of those six are always set to zero
+because they specify trasfer income that is not taxed under the
+federal income tax or because they specify rent paid that does not
+affect federal income tax liability.  Three of the remaining four
+input variables are itemized expense amounts and the fourth is
+child-care expenses. (This is the b17 assumption set.)

--- a/taxcalc/validation/taxsim/a17.taxdiffs-expect
+++ b/taxcalc/validation/taxsim/a17.taxdiffs-expect
@@ -1,4 +1,3 @@
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 19    941    941     -0.01 [185]
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27     26     26     -0.01 [2594]
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28     68     68     -0.01 [1064]
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4    102    102     -0.01 [874]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27     65     65     -0.01 [1929]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28     29     29     -0.01 [2188]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4     54     54     -0.01 [237]

--- a/taxcalc/validation/taxsim/b17.taxdiffs-expect
+++ b/taxcalc/validation/taxsim/b17.taxdiffs-expect
@@ -1,4 +1,3 @@
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 19   1014   1014     -0.01 [874]
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27     21     21     -0.01 [3212]
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28     74     74     -0.01 [2859]
-TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4     18     18     -0.01 [874]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27    166    166      0.01 [11]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28    660    660     -0.01 [72]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4    131    131     -0.01 [72]

--- a/taxcalc/validation/taxsim/taxdiff.awk
+++ b/taxcalc/validation/taxsim/taxdiff.awk
@@ -10,7 +10,7 @@
 #           value of all the variable differences.
 
 BEGIN {
-    DUMP_MIN = 10 # absolute value of ovar4 difference must exceed this to dump
+    DUMP_MIN = 1 # absolute value of ovar4 difference must exceed this to dump
     file_number = 0
     file_name = ""
     if ( col == "4-25" ) {

--- a/taxcalc/validation/taxsim/taxdiffs.tcl
+++ b/taxcalc/validation/taxsim/taxdiffs.tcl
@@ -95,7 +95,6 @@ taxdiff $awkfilename 15 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 16 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 17 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 18 $out1_filename $out2_filename $dump
-taxdiff $awkfilename 19 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 22 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 23 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 24 $out1_filename $out2_filename $dump

--- a/taxcalc/validation/taxsim/taxsim_emulation.json
+++ b/taxcalc/validation/taxsim/taxsim_emulation.json
@@ -3,11 +3,11 @@
 //
 // (1) _II_brk6 for MARS=4 = 444500 (rather than 444550)
 //     This seems to be a typo in TAXSIM-27 source code.
-//     [This change was introduced for assumption set a and higher.]
+//     (This change was introduced for assumption set a and higher.)
 //
 // (2) _CG_brk2 for MARS=4 = 444500 (rather than 444550)
 //     This seems to be a typo in TAXSIM-27 source code.
-//     [This change was introduced for assumption set b and higher.]
+//     (This change was introduced for assumption set b and higher.)
 //
 // (3) _AMT_child_em_c_age = 24 (rather than 18)
 //     Whether to set this parameter to 18 or 24 is arbitary because
@@ -18,7 +18,7 @@
 //     assumption that only those under 18 are required to use the child
 //     AMT exemption rules, while TAXSIM-27 makes the arbitrary assumption
 //     that all those under 24 are required to use the child AMT exemption.
-//     [This change was introduced for assumption set b and higher.]
+//     (This change was introduced for assumption set b and higher.)
 //
 // (4) _EITC_excess_InvestIncome_rt = 1.0 (rather than 9e99)
 //     The rate at which the EITC amount is reduced per dollar of investment
@@ -33,7 +33,7 @@
 //     the magnitude of model-calculated marginal tax rates with respect to
 //     investment income in cases where a marginal increase in investment
 //     income takes a filing unit above the ceiling.
-//     [This change was introduced for assumption set b and higher.]
+//     (This change was introduced for assumption set b and higher.)
 //
 {
     "policy": {

--- a/taxcalc/validation/taxsim/taxsim_emulation.json
+++ b/taxcalc/validation/taxsim/taxsim_emulation.json
@@ -1,7 +1,15 @@
 // JSON "reform" file that specifies changes in current-law policy that
 // are required to make Tax-Calculator work like TAXSIM-27.
 //
-// (1) _AMT_child_em_c_age = 24 (rather than 18)
+// (1) _II_brk6 for MARS=4 = 444500 (rather than 444550)
+//     This seems to be a typo in TAXSIM-27 source code.
+//     [This change was introduced for assumption set a and higher.]
+//
+// (2) _CG_brk2 for MARS=4 = 444500 (rather than 444550)
+//     This seems to be a typo in TAXSIM-27 source code.
+//     [This change was introduced for assumption set b and higher.]
+//
+// (3) _AMT_child_em_c_age = 24 (rather than 18)
 //     Whether to set this parameter to 18 or 24 is arbitary because
 //     neither model has enough information to apply correctly the child
 //     AMT exemption rules.  Information on full-time student status and
@@ -12,7 +20,7 @@
 //     that all those under 24 are required to use the child AMT exemption.
 //     [This change was introduced for assumption set b and higher.]
 //
-// (2) _EITC_excess_InvestIncome_rt = 1.0 (rather than 9e99)
+// (4) _EITC_excess_InvestIncome_rt = 1.0 (rather than 9e99)
 //     The rate at which the EITC amount is reduced per dollar of investment
 //     income in excess of the EITC investment income ceiling is infinity under
 //     current law (that is, any investment income in excess of the ceiling
@@ -23,12 +31,16 @@
 //     with some of the differences being in the thousands of dollars.  This
 //     non-current-law assumption in TAXSIM-27 is presumably made to reduce
 //     the magnitude of model-calculated marginal tax rates with respect to
-//     investment income in cases where the marginal increase in investment
+//     investment income in cases where a marginal increase in investment
 //     income takes a filing unit above the ceiling.
 //     [This change was introduced for assumption set b and higher.]
 //
 {
     "policy": {
+
+        "_II_brk6": {"2017": [[418400, 470700, 235350, 444500, 470700]]},
+        
+        "_CG_brk2": {"2017": [[418400, 470700, 235350, 444500, 470700]]},
 
         "_AMT_child_em_c_age": {"2013": [24]},
 

--- a/taxcalc/validation/taxsim/taxsim_input.py
+++ b/taxcalc/validation/taxsim/taxsim_input.py
@@ -93,9 +93,9 @@ def assumption_set(year, letter):
         adict['max_dep17'] = 4  # TAXSIM ivar 9 (Child Credit)
         adict['max_dep18'] = 4  # TAXSIM ivar 10 (EITC)
         # labor income:
-        adict['max_pwages_yng'] = 300  # TAXSIM ivar 11
+        adict['max_pwages_yng'] = 500  # TAXSIM ivar 11
         adict['max_pwages_old'] = 30  # TAXSIM ivar 11 (65+ ==> old)
-        adict['max_swages_yng'] = 300  # TAXSIM ivar 12
+        adict['max_swages_yng'] = 500  # TAXSIM ivar 12
         adict['max_swages_old'] = 30  # TAXSIM ivar 12 (65+ ==> old)
         # non-labor income:
         adict['max_divinc'] = 0  # TAXSIM ivar 13
@@ -104,9 +104,7 @@ def assumption_set(year, letter):
         adict['max_stcg'] = 0  # TAXSIM ivar 15
         adict['min_ltcg'] = 0  # TAXSIM ivar 16
         adict['max_ltcg'] = 0  # TAXSIM ivar 16
-        adict['min_other_prop_inc'] = 0  # TAXSIM ivar 17
         adict['max_other_prop_inc'] = 0  # TAXSIM ivar 17
-        adict['min_other_nonprop_inc'] = 0  # TAXSIM ivar 18
         adict['max_other_nonprop_inc'] = 0  # TAXSIM ivar 18
         adict['max_pnben'] = 0  # TAXSIM ivar 19
         adict['max_ssben'] = 0  # TAXSIM ivar 20
@@ -118,26 +116,24 @@ def assumption_set(year, letter):
         adict['max_ided_mortgage'] = 0  # TAXSIM ivar 27
         # end if letter in VALID_LETTERS
     if letter == 'b':  # <=====================================================
+        adict['max_divinc'] = 20  # TAXSIM ivar 13
         adict['max_intinc'] = 20  # TAXSIM ivar 14
-        """
-        adict['max_divinc'] = 10  # TAXSIM ivar 13
         adict['min_stcg'] = -10  # TAXSIM ivar 15
         adict['max_stcg'] = 10  # TAXSIM ivar 15
         adict['min_ltcg'] = -10  # TAXSIM ivar 16
         adict['max_ltcg'] = 10  # TAXSIM ivar 16
-        adict['min_other_prop_inc'] = 0  # TAXSIM ivar 17
-        adict['max_other_prop_inc'] = 0  # TAXSIM ivar 17
-        adict['min_other_nonprop_inc'] = 0  # TAXSIM ivar 18
-        adict['max_other_nonprop_inc'] = 0  # TAXSIM ivar 18
+        adict['max_other_prop_inc'] = 30  # TAXSIM ivar 17
+        adict['max_other_nonprop_inc'] = 30  # TAXSIM ivar 18
         adict['max_pnben'] = 60  # TAXSIM ivar 19
         adict['max_ssben'] = 60  # TAXSIM ivar 20
         adict['max_uiben'] = 10  # TAXSIM ivar 21
+
         # itemized and childcare expense amounts:
-        adict['max_ided_proptax'] = 0  # TAXSIM ivar 24
-        adict['max_ided_nopref'] = 0  # TAXSIM ivar 25
-        adict['max_ccexp'] = 15  # TAXSIM ivar 26
-        adict['max_ided_mortgage'] = 0  # TAXSIM ivar 27
-        """
+        # adict['max_ided_proptax'] = 0  # TAXSIM ivar 24
+        # adict['max_ided_nopref'] = 0  # TAXSIM ivar 25
+        # adict['max_ccexp'] = 15  # TAXSIM ivar 26
+        # adict['max_ided_mortgage'] = 0  # TAXSIM ivar 27
+
     return adict
 
 
@@ -204,11 +200,11 @@ def sample_dataframe(assump, year, offset):
                                           assump['max_ltcg'],
                                           size) * 1000
     # (17) OTHERPROP
-    sdict[17] = np.random.random_integers(assump['min_other_prop_inc'],
+    sdict[17] = np.random.random_integers(0,
                                           assump['max_other_prop_inc'],
                                           size) * 1000
     # (18) NONPROP
-    sdict[18] = np.random.random_integers(assump['min_other_nonprop_inc'],
+    sdict[18] = np.random.random_integers(0,
                                           assump['max_other_nonprop_inc'],
                                           size) * 1000
     # (19) PENSIONS


### PR DESCRIPTION
This pull request expands the scope of input variables used in the Tax-Calculator versus TAXSIM-27 validation work.  Now the amounts for all income variables are being randomly specified.  Only the input variables for child-care expense and the three input variables for itemized-deduction expense are zero for all the filing units.

See the `taxcalc/validation/taxsim/README.md` file for details.