### PR TITLE
Revise taxsim_input.py to generate valid dependent-expense input

### DIFF
--- a/taxcalc/validation/taxsim/taxsim_input.py
+++ b/taxcalc/validation/taxsim/taxsim_input.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 
-VALID_LETTERS = ['a', 'b']
+VALID_LETTERS = ['a', 'b', 'c']
 
 
 def main():
@@ -138,6 +138,9 @@ def assumption_set(year, letter):
         adict['max_ccexp'] = 15  # TAXSIM ivar 26
         adict['max_ided_mortgage'] = 0  # TAXSIM ivar 27
         """
+    if letter == 'c':  # <=====================================================
+        adict['max_ccexp'] = 10  # TAXSIM ivar 26
+
     return adict
 
 
@@ -229,8 +232,9 @@ def sample_dataframe(assump, year, offset):
     sdict[25] = np.random.random_integers(0,
                                           assump['max_ided_nopref'],
                                           size) * 1000
-    # (26) CHILDCARE
-    sdict[26] = np.random.random_integers(0, assump['max_ccexp'], size) * 1000
+    # (26) CHILDCARE (TAXSIM-27 EXPECTS ZERO IF NO QUALIFYING CHILDRED)
+    ccexp = np.random.random_integers(0, assump['max_ccexp'], size) * 1000
+    sdict[26] = np.where(dep13 > 0, ccexp, zero)
     # (27) MORTGAGE
     sdict[27] = np.random.random_integers(0,
                                           assump['max_ided_mortgage'],


### PR DESCRIPTION
This pull request changes the logic of `taxsim_input.py` so that it generates childcare expense (ivar=26) input that TAXSIM-27 considers valid.  Namely, if the number of children under 13 (ivar=8) is zero and childcare expense (ivar=26) is positive, TAXSIM-27 will give a childcare credit (even though there are no qualifying children).  So, `taxsim_input.py` logic has been revised to set childcare expense equal to zero if the number of children under age 13 is zero.