### PR TITLE
Add MTR variables to .out-taxcalc files and compare MTR variables

### DIFF
--- a/taxcalc/validation/taxsim/a17.taxdiffs-expect
+++ b/taxcalc/validation/taxsim/a17.taxdiffs-expect
@@ -1,3 +1,4 @@
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  9    109      0      0.90 [88]
 TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27     65     65     -0.01 [1929]
 TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28     29     29     -0.01 [2188]
 TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4     54     54     -0.01 [237]

--- a/taxcalc/validation/taxsim/b17.taxdiffs-expect
+++ b/taxcalc/validation/taxsim/b17.taxdiffs-expect
@@ -1,3 +1,5 @@
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  7      2      0     -0.34 [97290]
+TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  9    109      0      0.90 [88]
 TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 27    166    166      0.01 [11]
 TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]= 28    660    660     -0.01 [72]
 TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]=  4    131    131     -0.01 [72]

--- a/taxcalc/validation/taxsim/process_taxcalc_output.py
+++ b/taxcalc/validation/taxsim/process_taxcalc_output.py
@@ -100,9 +100,9 @@ def extract_output(out):
     ovar[4] = out['iitax']  # federal income tax liability
     ovar[5] = 0.0  # no state income tax calculation
     ovar[6] = out['payrolltax']  # ee+er for OASDI+HI
-    ovar[7] = 0.0  # marginal federal income tax rate as percent
+    ovar[7] = out['mtr_inctax']  # marginal federal income tax rate as percent
     ovar[8] = 0.0  # no state income tax calculation
-    ovar[9] = 0.0  # marginal payroll tax rate as percent
+    ovar[9] = out['mtr_paytax']  # marginal payroll tax rate as percent
     ovar[10] = out['c00100']  # federal AGI
     ovar[11] = out['e02300']  # UI benefits in AGI
     ovar[12] = out['c02500']  # OASDI benefits in AGI

--- a/taxcalc/validation/taxsim/taxdiffs.tcl
+++ b/taxcalc/validation/taxsim/taxdiffs.tcl
@@ -87,6 +87,8 @@ if { $ovar4 == 1 } {
     exit 0
 }
 taxdiff $awkfilename  6 $out1_filename $out2_filename $dump
+taxdiff $awkfilename  7 $out1_filename $out2_filename $dump
+taxdiff $awkfilename  9 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 10 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 11 $out1_filename $out2_filename $dump
 taxdiff $awkfilename 12 $out1_filename $out2_filename $dump


### PR DESCRIPTION
This pull request adds the MTR variables included in the `tc --dump` output to the TAXSIM-27 formatted `.out-taxcalc` files.  It also revises `taxdiffs.tcl` to compare the MTR variables.