### PR TITLE
Update documentation for release 0.24.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@ TAX-CALCULATOR CHANGE HISTORY
 =============================
 
 
+Changes in release 0.24.0 on 2018-12-14
+---------------------------------------
+
+- Make taxcalc packages available for Python 3.7 as well as for Python 3.6.
+
+
 Changes in release 0.23.4 on 2018-12-13
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![PSL cataloged](https://img.shields.io/badge/PSL-cataloged-a0a0a0.svg)](https://www.PSLmodels.org)
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![Python 3.6+](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![Build Status](https://travis-ci.org/PSLmodels/Tax-Calculator.svg?branch=master)](https://travis-ci.org/PSLmodels/Tax-Calculator)
 [![Codecov](https://codecov.io/gh/PSLmodels/Tax-Calculator/branch/master/graph/badge.svg)](https://codecov.io/gh/PSLmodels/Tax-Calculator)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,23 @@ Go [here](https://github.com/PSLmodels/Tax-Calculator/pulls?q=is%3Apr+is%3Aclose
 for a complete commit history.
 
 
+2018-12-14 Release 0.24.0
+-------------------------
+(last merged pull request is
+[#2176](https://github.com/PSLmodels/Tax-Calculator/pull/2176))
+
+**API Changes**
+- None
+
+**New Features**
+- Make taxcalc packages available for Python 3.7 as well as for Python 3.6
+  [[#2176](https://github.com/PSLmodels/Tax-Calculator/pull/2176)
+  by Martin Holmer]
+
+**Bug Fixes**
+- None
+
+
 2018-12-13 Release 0.23.4
 -------------------------
 (last merged pull request is
@@ -18,7 +35,7 @@ for a complete commit history.
   by Martin Holmer]
 
 **Bug Fixes**
-- fix obscure bug regarding rules for determining eligibility for the child AMT exemption that was discovered during [validation work](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/validation/taxsim/README.md#validation-of-tax-calculator-against-internet-taxsim-version-27)
+- Fix obscure bug regarding rules for determining eligibility for the child AMT exemption that was discovered during [validation work](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/validation/taxsim/README.md#validation-of-tax-calculator-against-internet-taxsim-version-27)
   [[#2162](https://github.com/PSLmodels/Tax-Calculator/pull/2162)
   by Martin Holmer]
 

--- a/docs/index.htmx
+++ b/docs/index.htmx
@@ -217,9 +217,9 @@ files to TaxBrain.</p>
 
 <p><b>Install the free Anaconda Python distribution</b> by going to
 the <a href="https://www.anaconda.com/download/">Anaconda download
-page</a> and selecting Python 3.6.  You should install Python 3.6
-because we have discontinued support for Python 2.7 and are not yet
-supporting Python 3.7.  You must do this installation even if you already
+page</a> and selecting Python 3.6 or Python 3.7.  You should install
+Python 3.6+ because we have discontinued support for Python 2.7.
+You must do this installation even if you already
 have Python installed on your computer because the Anaconda
 distribution contains all the additional Python packages that
 Tax-Calculator uses to conduct tax calculations (many of which are not
@@ -234,11 +234,12 @@ following two commands at the operating system command prompt (which
 is shown as <kbd>$</kbd> here, but would be <kbd>></kbd> on Windows)
 in any directory:
 <pre>$ conda --version</pre>
-Expected output is something like <kbd>conda 4.4.7</kbd>
+Expected output is something like <kbd>conda 4.5.11</kbd>
 <pre>$ python --version</pre>
-Expected output should contain the <kbd>Python 3.6</kbd> phrase as
-well as the <kbd>Anaconda</kbd> phrase, the presence of which confirm
-that the installation went smoothly.</p>
+Expected output should contain the <kbd>Python 3.6</kbd> or the
+<kbd>Python 3.7</kbd> phrase as well as the <kbd>Anaconda</kbd>
+phrase, the presence of which confirm that the installation went
+smoothly.</p>
 
 <p><b>Install the free taxcalc package</b> by entering the following:
 <pre>$ conda install -c PSLmodels taxcalc</pre>

--- a/read-the-docs/source/contributor_guide.rst
+++ b/read-the-docs/source/contributor_guide.rst
@@ -18,8 +18,8 @@ Setup Python
 -------------
 
 The Tax-Calculator is written in the Python programming language.
-Download and install the free Anaconda distribution of Python 3.6
-from `Anaconda`_.  You must do this even if you already have
+Download and install the free Anaconda distribution of Python 3.6 or
+Python 3.7 from `Anaconda`_.  You must do this even if you already have
 Python installed on your computer because the Anaconda distribution
 contains all the additional Python packages that we use to conduct tax
 calculations (many of which are not included in other Python


### PR DESCRIPTION
Changes only in documentation to say that can install either Python 3.6 or 3.7 to use Tax-Calculator source code or taxcalc package.