### PR TITLE
Update docs with respect to Python 3.7

### DIFF
--- a/docs/cookbook.html
+++ b/docs/cookbook.html
@@ -15,8 +15,9 @@ Tax-Calculator</h1>
 <p>This document tells you how to use Tax-Calculator, an open-source
 federal income and payroll tax simulation model, in Python scripts
 that you can run on your own computer.  Note that these recipes
-require Tax-Calculator release 0.23.4 or higher running on Python 3.6.
-For other ways of using Tax-Calculator, see the
+require either (1) Tax-Calculator release 0.23.4 or higher running on
+Python 3.6, or (2) Tax-Calculator release 0.24.0 or higher running on
+Python 3.7.  For other ways of using Tax-Calculator, see the
 <a href="https://PSLmodels.github.io/Tax-Calculator/">
 user documentation</a>, which this Cookbook assumes you have read.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -218,9 +218,9 @@ files to TaxBrain.</p>
 
 <p><b>Install the free Anaconda Python distribution</b> by going to
 the <a href="https://www.anaconda.com/download/">Anaconda download
-page</a> and selecting Python 3.6.  You should install Python 3.6
-because we have discontinued support for Python 2.7 and are not yet
-supporting Python 3.7.  You must do this installation even if you already
+page</a> and selecting Python 3.6 or Python 3.7.  You should install
+Python 3.6+ because we have discontinued support for Python 2.7.
+You must do this installation even if you already
 have Python installed on your computer because the Anaconda
 distribution contains all the additional Python packages that
 Tax-Calculator uses to conduct tax calculations (many of which are not
@@ -235,11 +235,12 @@ following two commands at the operating system command prompt (which
 is shown as <kbd>$</kbd> here, but would be <kbd>></kbd> on Windows)
 in any directory:
 <pre>$ conda --version</pre>
-Expected output is something like <kbd>conda 4.4.7</kbd>
+Expected output is something like <kbd>conda 4.5.11</kbd>
 <pre>$ python --version</pre>
-Expected output should contain the <kbd>Python 3.6</kbd> phrase as
-well as the <kbd>Anaconda</kbd> phrase, the presence of which confirm
-that the installation went smoothly.</p>
+Expected output should contain the <kbd>Python 3.6</kbd> or the
+<kbd>Python 3.7</kbd> phrase as well as the <kbd>Anaconda</kbd>
+phrase, the presence of which confirm that the installation went
+smoothly.</p>
 
 <p><b>Install the free taxcalc package</b> by entering the following:
 <pre>$ conda install -c PSLmodels taxcalc</pre>


### PR DESCRIPTION
This pull request changes only the documentation to make it clear that as of Tax-Calculator release 0.24.0 conda `taxcalc` packages are available for Python 3.7 as well as Python 3.6.