### PR TITLE
Increase max_waits in reforms test setup/teardown logic

### DIFF
--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -60,7 +60,7 @@ def fixture_test_reforms(tests_path):
     actfile_path = os.path.join(tests_path, 'reforms_actual.csv')
     afiles = os.path.join(tests_path, 'reform_actual_*.csv')
     wait_secs = 1
-    max_waits = 40
+    max_waits = 120
     # test_reforms setup
     if handling_logic:
         # remove reforms_actual.csv file if exists


### PR DESCRIPTION
Make the setup and teardown logic for the reforms tests be more patient.
No change in tax logic or results.