### PR TITLE
Add pytest-setup logic to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ clean:
 package:
 	@cd conda.recipe ; ./install_local_package.sh
 
+define pytest-setup
+rm -f taxcalc/tests/reforms_actual_init
+endef
+
 define pytest-cleanup
 find . -name *cache -maxdepth 1 -exec rm -r {} \;
 rm -f df-??-#-*
@@ -46,16 +50,19 @@ endef
 
 .PHONY=pytest-cps
 pytest-cps:
+	@$(pytest-setup)
 	@cd taxcalc ; pytest -n4 -m "not requires_pufcsv and not pre_release"
 	@$(pytest-cleanup)
 
 .PHONY=pytest
 pytest:
+	@$(pytest-setup)
 	@cd taxcalc ; pytest -n4 -m "not pre_release"
 	@$(pytest-cleanup)
 
 .PHONY=pytest-all
 pytest-all:
+	@$(pytest-setup)
 	@cd taxcalc ; pytest -n4 -m ""
 	@$(pytest-cleanup)
 

--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -60,7 +60,7 @@ def fixture_test_reforms(tests_path):
     actfile_path = os.path.join(tests_path, 'reforms_actual.csv')
     afiles = os.path.join(tests_path, 'reform_actual_*.csv')
     wait_secs = 1
-    max_waits = 120
+    max_waits = 60
     # test_reforms setup
     if handling_logic:
         # remove reforms_actual.csv file if exists


### PR DESCRIPTION
This minor revision to Makefile logic makes the running of the `pytest` test suite more safe.
No change in tax logic or results.