### PR TITLE
Replace urllib with requests package

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,6 +12,7 @@ requirements:
     - "numpy>=1.13"
     - "pandas>=0.23"
     - "bokeh>=0.13"
+    - requests
     - numba
 
   run:
@@ -19,6 +20,7 @@ requirements:
     - "numpy>=1.13"
     - "pandas>=0.23"
     - "bokeh>=0.13"
+    - requests
     - numba
 
 test:

--- a/docs/cookbook/recipe02.py
+++ b/docs/cookbook/recipe02.py
@@ -31,7 +31,7 @@ itax_rev2sa = calc2.weighted_total('iitax')
 
 # specify behavioral-response assumptions
 behresp_json = '{"BE_sub": {"2018": 0.25}}'
-behresp_dict = Calculator.read_json_assumptions(behresp_json)
+behresp_dict = Calculator.read_json_parameters(behresp_json)
 
 # specify Calculator object for analysis of reform with behavioral response
 calc2 = Calculator(policy=pol, records=recs)

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ dependencies:
 - "numpy>=1.13"
 - "pandas>=0.23"
 - "bokeh>=0.13"
+- requests
 - numba
 - pytest
 - pytest-pep8

--- a/taxcalc/assumptions/economic_assumptions_template.json
+++ b/taxcalc/assumptions/economic_assumptions_template.json
@@ -7,6 +7,10 @@
 // <http://PSLmodels.github.io/Tax-Calculator/#params>.
 {
     "consumption": {
+        "_MPC_e17500": {"2017": [0.0]},
+        "_MPC_e18400": {"2017": [0.0]},
+        "_MPC_e19800": {"2017": [0.0]},
+        "_MPC_e20400": {"2017": [0.0]},
         "_BEN_housing_value": {"2017": [1.0]},
         "_BEN_snap_value": {"2017": [1.0]},
         "_BEN_tanf_value": {"2017": [1.0]},
@@ -14,11 +18,7 @@
         "_BEN_wic_value": {"2017": [1.0]},
         "_BEN_mcare_value": {"2017": [1.0]},
         "_BEN_mcaid_value": {"2017": [1.0]},
-        "_BEN_other_value": {"2017": [1.0]},
-        "_MPC_e17500": {"2017": [0.0]},
-        "_MPC_e18400": {"2017": [0.0]},
-        "_MPC_e19800": {"2017": [0.0]},
-        "_MPC_e20400": {"2017": [0.0]}
+        "_BEN_other_value": {"2017": [1.0]}
     },
     "growdiff_baseline": {
         "_ABOOK": {"2017": [0.0]},

--- a/taxcalc/assumptions/simple_parameters_template.json
+++ b/taxcalc/assumptions/simple_parameters_template.json
@@ -1,0 +1,10 @@
+// Sample JSON parameter file suitable for Calculator.read_json_parameters(),
+// which is a function used by other PSL models to read simple parameter
+// schema that do not involve the use of [] brackets around parameter values
+// and that do not involve parameter with vector values or parameters that are
+// inflation indexed.
+{
+  "BE_sub": {"2018": -0.05, "2021": -0.25},
+  "BE_inc": {"2020": 0.10},
+  "BE_cg": {"2022": -0.70}
+}

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -10,7 +10,7 @@ Tax-Calculator federal income and payroll tax Calculator class.
 import os
 import re
 import copy
-import urllib
+import requests
 import numpy as np
 import pandas as pd
 from taxcalc.calcfunctions import (TaxInc, SchXYZTax, GainsTax, AGIsurtax,
@@ -1102,7 +1102,9 @@ class Calculator():
             if os.path.isfile(assump):
                 txt = open(assump, 'r').read()
             elif assump.startswith('http'):
-                txt = urllib.request.urlopen(assump).read().decode()
+                req = requests.get(assump)
+                req.raise_for_status()
+                txt = req.text
             else:
                 txt = assump
             (cons_dict,
@@ -1117,7 +1119,9 @@ class Calculator():
             if os.path.isfile(reform):
                 txt = open(reform, 'r').read()
             elif reform.startswith('http'):
-                txt = urllib.request.urlopen(reform).read().decode()
+                req = requests.get(reform)
+                req.raise_for_status()
+                txt = req.text
             else:
                 txt = reform
             rpol_dict = (
@@ -1159,7 +1163,9 @@ class Calculator():
             if os.path.isfile(assump):
                 txt = open(assump, 'r').read()
             elif assump.startswith('http'):
-                txt = urllib.request.urlopen(assump).read().decode()
+                req = requests.get(assump)
+                req.raise_for_status()
+                txt = req.text
             else:
                 txt = assump
             # strip out //-comments without changing line numbers

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1141,40 +1141,42 @@ class Calculator():
         return param_dict
 
     @staticmethod
-    def read_json_assumptions(assump):
+    def read_json_parameters(param):
         """
-        Read JSON assump object and return one dictionary that has
+        Read JSON param object and return one dictionary that has
         the same structure as each subdictionary returned by the
         Calculator.read_json_param_objects method.
 
-        Note that the assump argument can be None, in which case
+        Note that the param argument can be None, in which case
         the returned dictionary is empty.  Also note that the
-        assump argument can be a string containing a local file name,
+        param argument can be a string containing a local file name,
         URL beginning with 'http', or valid JSON string.
 
-        The assump file/URL contents or JSON string must be like the
+        The param file/URL contents or JSON string must be like the
         structure required for each subsection of the assump argument
-        of the Calculator.read_json_param_objects method.
+        of the Calculator.read_json_param_objects method EXCEPT FOR
+        ONE THING: the parameter values are NOT enclosed in [] brackets.
         """
         # construct returned dictionary from specified assump
-        if assump is None:
+        if param is None:
             returned_dict = dict()
-        elif isinstance(assump, str):
-            if os.path.isfile(assump):
-                txt = open(assump, 'r').read()
-            elif assump.startswith('http'):
-                req = requests.get(assump)
+        elif isinstance(param, str):
+            if os.path.isfile(param):
+                txt = open(param, 'r').read()
+            elif param.startswith('http'):
+                req = requests.get(param)
                 req.raise_for_status()
                 txt = req.text
+                print(txt)
             else:
-                txt = assump
+                txt = param
             # strip out //-comments without changing line numbers
             json_text = re.sub('//.*', ' ', txt)
             # convert JSON text into a Python dictionary
             raw_dict = json_to_dict(json_text)
             returned_dict = Calculator._convert_parameter_dict(raw_dict)
         else:
-            raise ValueError('assump is neither None nor string')
+            raise ValueError('param is neither None nor string')
         return returned_dict
 
     @staticmethod
@@ -1583,15 +1585,15 @@ class Calculator():
         year_param = dict()
         for pkey, sdict in param_key_dict.items():
             if not isinstance(pkey, str):
-                msg = 'pkey {} in reform is not a string'
+                msg = 'pkey {} in param JSON is not a string'
                 raise ValueError(msg.format(pkey))
             rdict = dict()
             if not isinstance(sdict, dict):
-                msg = 'pkey {} in reform is not paired with a dict'
+                msg = 'pkey {} in param JSON is not paired with a dict'
                 raise ValueError(msg.format(pkey))
             for skey, val in sdict.items():
                 if not isinstance(skey, str):
-                    msg = 'skey {} in reform is not a string'
+                    msg = 'skey {} in param JSON is not a string'
                     raise ValueError(msg.format(skey))
                 else:
                     year = int(skey)

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -12,8 +12,8 @@ import json
 from io import StringIO
 import tempfile
 import copy
-import urllib
 import pytest
+import requests
 import numpy as np
 import pandas as pd
 from taxcalc import Policy, Records, Calculator, Consumption
@@ -1213,7 +1213,7 @@ def test_read_json_assumptions(assumption_file):
     assert isinstance(Calculator.read_json_assumptions(None), dict)
     with pytest.raises(ValueError):
         Calculator.read_json_assumptions(list())
-    with pytest.raises(urllib.request.URLError):
+    with pytest.raises(requests.exceptions.ConnectionError):
         Calculator.read_json_assumptions('http://unknown-url')
     assump_filename = assumption_file.name
     file_dict = Calculator.read_json_assumptions(assump_filename)

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -1224,8 +1224,8 @@ def test_read_json_parameters(parameter_file):
     assert text_dict == file_dict
     with pytest.raises(requests.exceptions.ConnectionError):
         Calculator.read_json_parameters('http://unknown-url')
-    param_url = ('https://raw.githubusercontent.com/'
+    params_url = ('https://raw.githubusercontent.com/'
                   'PSLmodels/Tax-Calculator/master/taxcalc/'
                   'assumptions/simple_parameters_template.json')
-    # TODO: file_dict = Calculator.read_json_parameters(param_url)
+    # TODO: file_dict = Calculator.read_json_parameters(params_url)
     # TODO: assert isinstance(file_dict, dict)

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -1179,8 +1179,9 @@ def test_ce_aftertax_income(cps_subsample):
     assert isinstance(res, dict)
 
 
-ASSUMPTION_FILE_CONTENT = """
-// Example of JSON assump file suitable for read_json_assumptions().
+PARAMETER_FILE_CONTENT = """
+// Example of JSON parameter file suitable for read_json_parameters().
+// Notice the lack of [] brackets around the parameter values.
 {
   "BE_sub": {"2018": -0.05, "2021": -0.25},
   "BE_inc": {"2020": 0.10},
@@ -1189,35 +1190,42 @@ ASSUMPTION_FILE_CONTENT = """
 """
 
 
-@pytest.fixture(scope='module', name='assumption_file')
-def fixture_assumption_file():
+@pytest.fixture(scope='module', name='parameter_file')
+def fixture_parameter_file():
     """
-    Temporary assumption file for read_json_assumptions() function.
+    Temporary parameter file for read_json_parameters() function.
     """
-    afile = tempfile.NamedTemporaryFile(mode='a', delete=False)
-    afile.write(ASSUMPTION_FILE_CONTENT)
-    afile.close()
+    pfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    pfile.write(PARAMETER_FILE_CONTENT)
+    pfile.close()
     # must close and then yield for Windows platform
-    yield afile
-    if os.path.isfile(afile.name):
+    yield pfile
+    if os.path.isfile(pfile.name):
         try:
-            os.remove(afile.name)
+            os.remove(pfile.name)
         except OSError:
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_read_json_assumptions(assumption_file):
+def test_read_json_parameters(parameter_file):
     """
-    Test Calculator.read_json_assumptions() function.
+    Test the Calculator.read_json_() function that is used by
+    other PSLmodels models to read simple parameter schema that
+    do not involve the use of [] brackets around parameter values.
     """
-    assert isinstance(Calculator.read_json_assumptions(None), dict)
+    assert isinstance(Calculator.read_json_parameters(None), dict)
     with pytest.raises(ValueError):
-        Calculator.read_json_assumptions(list())
-    with pytest.raises(requests.exceptions.ConnectionError):
-        Calculator.read_json_assumptions('http://unknown-url')
-    assump_filename = assumption_file.name
-    file_dict = Calculator.read_json_assumptions(assump_filename)
+        Calculator.read_json_parameters(list())
+    param_filename = parameter_file.name
+    file_dict = Calculator.read_json_parameters(param_filename)
     assert isinstance(file_dict, dict)
-    text_dict = Calculator.read_json_assumptions(ASSUMPTION_FILE_CONTENT)
+    text_dict = Calculator.read_json_parameters(PARAMETER_FILE_CONTENT)
     assert isinstance(text_dict, dict)
     assert text_dict == file_dict
+    with pytest.raises(requests.exceptions.ConnectionError):
+        Calculator.read_json_parameters('http://unknown-url')
+    param_url = ('https://raw.githubusercontent.com/'
+                  'PSLmodels/Tax-Calculator/master/taxcalc/'
+                  'assumptions/simple_parameters_template.json')
+    # TODO: file_dict = Calculator.read_json_parameters(param_url)
+    # TODO: assert isinstance(file_dict, dict)


### PR DESCRIPTION
This pull request simplifies the code by replacing the `urllib` with the `requests` package as recommended by @hdoupe in issue #2224.

The return to complete code coverage with the pytest suite will be achieved in a subsequent pull request.