### PR TITLE
Move nonsmall_diffs function from utils.py to several test_*.py files

### DIFF
--- a/taxcalc/tests/test_cpscsv.py
+++ b/taxcalc/tests/test_cpscsv.py
@@ -17,7 +17,7 @@ import json
 import numpy as np
 import pandas as pd
 # pylint: disable=import-error
-from taxcalc import Policy, Records, Calculator, nonsmall_diffs
+from taxcalc import Policy, Records, Calculator
 from taxcalc import run_nth_year_taxcalc_model
 
 
@@ -109,6 +109,54 @@ def test_cps_availability(tests_path, cps_path):
     # check that cpsvars and recvars sets are the same
     assert (cpsvars - recvars) == set()
     assert (recvars - cpsvars) == set()
+
+
+def nonsmall_diffs(linelist1, linelist2, small=0.0):
+    """
+    Return True if line lists differ significantly; otherwise return False.
+    Significant numerical difference means one or more numbers differ (between
+    linelist1 and linelist2) by more than the specified small amount.
+    """
+    # embedded function used only in nonsmall_diffs function
+    def isfloat(value):
+        """
+        Return True if value can be cast to float; otherwise return False.
+        """
+        try:
+            float(value)
+            return True
+        except ValueError:
+            return False
+    # begin nonsmall_diffs logic
+    assert isinstance(linelist1, list)
+    assert isinstance(linelist2, list)
+    if len(linelist1) != len(linelist2):
+        return True
+    assert 0.0 <= small <= 1.0
+    epsilon = 1e-6
+    smallamt = small + epsilon
+    for line1, line2 in zip(linelist1, linelist2):
+        if line1 == line2:
+            continue
+        else:
+            tokens1 = line1.replace(',', '').split()
+            tokens2 = line2.replace(',', '').split()
+            for tok1, tok2 in zip(tokens1, tokens2):
+                tok1_isfloat = isfloat(tok1)
+                tok2_isfloat = isfloat(tok2)
+                if tok1_isfloat and tok2_isfloat:
+                    if abs(float(tok1) - float(tok2)) <= smallamt:
+                        continue
+                    else:
+                        return True
+                elif not tok1_isfloat and not tok2_isfloat:
+                    if tok1 == tok2:
+                        continue
+                    else:
+                        return True
+                else:
+                    return True
+        return False
 
 
 def test_run_taxcalc_model(tests_path):

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -989,3 +989,15 @@ def test_reform_with_cpi_offset():
     pol = Policy()  # current-law policy
     pol.implement_reform(indexing_reform)
     assert not pol.parameter_errors
+
+
+def test_reform_with_bad_CTC_levels():
+    """
+    Implement a reform with _ACTC > _CTC_c values.
+    """
+    child_credit_reform = {
+        2020: {'_CTC_c': [2200], '_ACTC_c': [2500]}
+    }
+    pol = Policy()
+    with pytest.raises(ValueError):
+        pol.implement_reform(child_credit_reform)

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -21,7 +21,7 @@ import pytest
 import numpy as np
 import pandas as pd
 # pylint: disable=import-error
-from taxcalc import Policy, Records, Calculator, nonsmall_diffs
+from taxcalc import Policy, Records, Calculator
 from taxcalc import run_nth_year_taxcalc_model
 
 
@@ -139,6 +139,54 @@ def mtr_bin_counts(mtr_data, bin_edges, recid):
                 if mtr_data[idx] > bin_max:
                     res += recinfo.format(mtr_data[idx], recid[idx])
     return res
+
+
+def nonsmall_diffs(linelist1, linelist2, small=0.0):
+    """
+    Return True if line lists differ significantly; otherwise return False.
+    Significant numerical difference means one or more numbers differ (between
+    linelist1 and linelist2) by more than the specified small amount.
+    """
+    # embedded function used only in nonsmall_diffs function
+    def isfloat(value):
+        """
+        Return True if value can be cast to float; otherwise return False.
+        """
+        try:
+            float(value)
+            return True
+        except ValueError:
+            return False
+    # begin nonsmall_diffs logic
+    assert isinstance(linelist1, list)
+    assert isinstance(linelist2, list)
+    if len(linelist1) != len(linelist2):
+        return True
+    assert 0.0 <= small <= 1.0
+    epsilon = 1e-6
+    smallamt = small + epsilon
+    for line1, line2 in zip(linelist1, linelist2):
+        if line1 == line2:
+            continue
+        else:
+            tokens1 = line1.replace(',', '').split()
+            tokens2 = line2.replace(',', '').split()
+            for tok1, tok2 in zip(tokens1, tokens2):
+                tok1_isfloat = isfloat(tok1)
+                tok2_isfloat = isfloat(tok2)
+                if tok1_isfloat and tok2_isfloat:
+                    if abs(float(tok1) - float(tok2)) <= smallamt:
+                        continue
+                    else:
+                        return True
+                elif not tok1_isfloat and not tok2_isfloat:
+                    if tok1 == tok2:
+                        continue
+                    else:
+                        return True
+                else:
+                    return True
+        return False
 
 
 @pytest.mark.requires_pufcsv

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -33,7 +33,6 @@ from taxcalc.utils import (DIST_VARIABLES,
                            bootstrap_se_ci,
                            certainty_equivalent,
                            ce_aftertax_expanded_income,
-                           nonsmall_diffs,
                            quantity_response)
 
 
@@ -845,15 +844,6 @@ def test_dec_graph_plots(cps_subsample):
                          include_zero_incomes=False,
                          include_negative_incomes=False)
     assert isinstance(dta, dict)
-
-
-def test_nonsmall_diffs():
-    assert nonsmall_diffs(['AAA'], ['AAA', 'BBB'])
-    assert nonsmall_diffs(['AaA'], ['AAA'])
-    assert not nonsmall_diffs(['AAA'], ['AAA'])
-    assert nonsmall_diffs(['12.3'], ['12.2'])
-    assert not nonsmall_diffs(['12.3 AAA'], ['12.2 AAA'], small=0.1)
-    assert nonsmall_diffs(['12.3'], ['AAA'])
 
 
 def test_quantity_response():

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1639,54 +1639,6 @@ def dec_graph_plot(data,
     return fig
 
 
-def nonsmall_diffs(linelist1, linelist2, small=0.0):
-    """
-    Return True if line lists differ significantly; otherwise return False.
-    Significant numerical difference means one or more numbers differ (between
-    linelist1 and linelist2) by more than the specified small amount.
-    """
-    # embedded function used only in nonsmall_diffs function
-    def isfloat(value):
-        """
-        Return True if value can be cast to float; otherwise return False.
-        """
-        try:
-            float(value)
-            return True
-        except ValueError:
-            return False
-    # begin nonsmall_diffs logic
-    assert isinstance(linelist1, list)
-    assert isinstance(linelist2, list)
-    if len(linelist1) != len(linelist2):
-        return True
-    assert 0.0 <= small <= 1.0
-    epsilon = 1e-6
-    smallamt = small + epsilon
-    for line1, line2 in zip(linelist1, linelist2):
-        if line1 == line2:
-            continue
-        else:
-            tokens1 = line1.replace(',', '').split()
-            tokens2 = line2.replace(',', '').split()
-            for tok1, tok2 in zip(tokens1, tokens2):
-                tok1_isfloat = isfloat(tok1)
-                tok2_isfloat = isfloat(tok2)
-                if tok1_isfloat and tok2_isfloat:
-                    if abs(float(tok1) - float(tok2)) <= smallamt:
-                        continue
-                    else:
-                        return True
-                elif not tok1_isfloat and not tok2_isfloat:
-                    if tok1 == tok2:
-                        continue
-                    else:
-                        return True
-                else:
-                    return True
-        return False
-
-
 def quantity_response(quantity,
                       price_elasticity,
                       aftertax_price1,


### PR DESCRIPTION
This pull request is part of an ongoing series of changes to simplify the pytest code by replacing the use of the `nonsmall_diffs` function by use of the `numpy.allclose` function.  This pull request moves the `nonsmall_diffs` function out of the `utils.py` file and puts it into several `test_*.py` where it is still being used.  In the future, we anticipate removing the use of the nested `nonsmall_diffs` functions in the tests where it is still being used.

Technically, the removal of the `nonsmall_diffs` function from the `utils.py` file is an API change, but I doubt any users of Tax-Calculator are using this utility function, which was designed for only one reason: to support the Tax-Calculator pytest suite when there were numerical differences between Python 2.7 and Python 3.6.