### PR TITLE
remove dc pension contributions from expanded income

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -1858,8 +1858,6 @@ def ExpandIncome(e00200, pencon_p, pencon_s, e00300, e00400, e00600,
     """
     expanded_income = (
         e00200 +  # wage and salary income net of DC pension contributions
-        pencon_p +  # tax-advantaged DC pension contributions for taxpayer
-        pencon_s +  # tax-advantaged DC pension contributions for spouse
         e00300 +  # taxable interest income
         e00400 +  # non-taxable interest income
         e00600 +  # dividends


### PR DESCRIPTION
This PR removes DC pension contributions from expanded income. 

Thanks to Alan Viard and Erin Melly for the suggestion. 

Alan provide a simple example to show how including both pension contributions and withdrawals will lead to the double counting of contributions. 

> Suppose a person earns $1,000, puts it in a plan, the investment draws $3,000 in returns, and the person withdraws $4,000. The current approach would include the initial $1,000 in income as well as the entire $4,000 withdrawal. That approach includes the initial $1,000 twice – only $3,000 of the $4,000 withdrawal is income earned on the investment.

In a separate email, Alan described some limitations of this approach. 

> This is a second-best issue with no fully satisfactory solution. If we could, we would obviously use the correct income measure (including the contribution and the return earned each year while excluding the withdrawal), but data limitations make that infeasible. Any feasible measure will be imperfect. My preferred approach (which Sita Slavov and I adopted in our Tax Notes article) is to exclude the contribution and include the withdrawal. That approach is self-consistent on a lifetime basis, but it diverges significantly from the correct income measure in each year. Inclusion of both the contribution and the withdrawal results in double counting (which would make it indefensible as  a tax base) and also diverges significantly from the correct income measure in many years, but it may diverge less than my preferred approach and it is a defensible annual income classifier. Some other organizations use such a classifier.     

This PR benefits from the discussions in #2194 and #2229. 