### PR TITLE
Fix warnings generated by new pylint version

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -1784,6 +1784,7 @@ def BenefitLimitation(calc):
         benefit_limit = deduct_exps * calc.policy_param('ID_BenefitCap_rt')
         # Add the difference between the actual benefit and capped benefit
         # to income tax and combined tax liabilities.
+        # pylint: disable=assignment-from-no-return
         excess_benefit = np.maximum(benefit - benefit_limit, 0)
         calc.incarray('iitax', excess_benefit)
         calc.incarray('surtax', excess_benefit)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1269,8 +1269,7 @@ class Calculator():
                         pval = pval[0]
                         if basevals[param]['boolean_value']:
                             if isinstance(pval, list):
-                                pval = [True if item else
-                                        False for item in pval]
+                                pval = [bool(item) for item in pval]
                             else:
                                 pval = bool(pval)
                     doc += ' {} : {}\n'.format(param, pval)
@@ -1303,8 +1302,7 @@ class Calculator():
                             if isinstance(bval, np.ndarray):
                                 bval = bval.tolist()
                                 if basevals[param]['boolean_value']:
-                                    bval = [True if item else
-                                            False for item in bval]
+                                    bval = [bool(item) for item in bval]
                             elif basevals[param]['boolean_value']:
                                 bval = bool(bval)
                         doc += '  baseline_value: {}\n'.format(bval)

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -140,6 +140,7 @@ class Records():
         if not np.allclose(self.e02100s[nospouse], zeros):
             raise ValueError(msg.format('e02100s'))
         # check that ordinary dividends are no less than qualified dividends
+        # pylint: disable=assignment-from-no-return
         other_dividends = np.maximum(0., self.e00600 - self.e00650)
         if not np.allclose(self.e00600, self.e00650 + other_dividends,
                            rtol=0.0, atol=tol):

--- a/taxcalc/tbi/tbi.py
+++ b/taxcalc/tbi/tbi.py
@@ -124,6 +124,7 @@ def run_nth_year_taxcalc_model(year_n, start_year,
         print('fuzzing_seed={}'.format(seed))
         np.random.seed(seed)
         # make bool array marking which filing units are affected by the reform
+        # pylint: disable=assignment-from-no-return
         reform_affected = np.logical_not(
             np.isclose(dv1['combined'], dv2['combined'], atol=0.01, rtol=0.0)
         )

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -190,8 +190,10 @@ def add_quantile_table_row_variable(dframe, income_measure, num_quantiles,
         assert bin_edges[1] > 1e-9  # bin_edges[1] is top of bottom decile
         neg_im = np.less_equal(dframe[income_measure], -1e-9)
         neg_wght = dframe['s006'][neg_im].sum()
-        zer_im = np.logical_and(np.greater(dframe[income_measure], -1e-9),
-                                np.less(dframe[income_measure], 1e-9))
+        zer_im = np.logical_and(  # pylint: disable=assignment-from-no-return
+            np.greater(dframe[income_measure], -1e-9),
+            np.less(dframe[income_measure], 1e-9)
+        )
         zer_wght = dframe['s006'][zer_im].sum()
         bin_edges.insert(1, neg_wght + zer_wght)  # top of zeros
         bin_edges.insert(1, neg_wght)  # top of negatives
@@ -924,6 +926,7 @@ def atr_graph_data(vdf, year,
     avgtax1_series = gdfx.apply(weighted_mean, 'tax1')
     avgtax2_series = gdfx.apply(weighted_mean, 'tax2')
     # compute average tax rates for each included income percentile
+    # pylint: disable=unsupported-assignment-operation
     atr1_series = np.zeros_like(avginc_series)
     atr1_series[included] = avgtax1_series[included] / avginc_series[included]
     atr2_series = np.zeros_like(avginc_series)
@@ -1086,6 +1089,7 @@ def pch_graph_data(vdf, year):
     avginc_series = gdfx.apply(weighted_mean, 'expanded_income')
     change_series = gdfx.apply(weighted_mean, 'chg_aftinc')
     # compute percentage change statistic each included income percentile
+    # pylint: disable=unsupported-assignment-operation
     pch_series = np.zeros_like(avginc_series)
     pch_series[included] = change_series[included] / avginc_series[included]
     # construct DataFrame containing the pch_series expressed as percent
@@ -1341,10 +1345,13 @@ def ce_aftertax_expanded_income(df1, df2,
     cedict['inc1'] = weighted_sum(df1, 'expanded_income') * billion
     cedict['inc2'] = weighted_sum(df2, 'expanded_income') * billion
     # calculate sample-weighted probability of each filing unit
-    prob_raw = np.divide(df1['s006'],  # pylint: disable=no-member
-                         df1['s006'].sum())
-    prob = np.divide(prob_raw,  # pylint: disable=no-member
-                     prob_raw.sum())  # handle any rounding error
+    prob_raw = np.divide(  # pylint: disable=assignment-from-no-return
+        df1['s006'], df1['s006'].sum()
+    )
+    # handle any rounding error in probability calculation
+    prob = np.divide(  # pylint: disable=assignment-from-no-return
+        prob_raw, prob_raw.sum()
+    )
     # calculate after-tax income of each filing unit in df1 and df2
     ati1 = df1['expanded_income'] - df1['combined']
     ati2 = df2['expanded_income'] - df2['combined']

--- a/taxcalc/validation/puf_fuzz.py
+++ b/taxcalc/validation/puf_fuzz.py
@@ -121,6 +121,7 @@ def constrain_data(xdf):
     # constraint: e02100 = e02100p + e02100s
     xdf['e02100'] = xdf['e02100p'] + xdf['e02100s']
     # constraint: e00600 >= e00650
+    # pylint: disable=assignment-from-no-return
     xdf['e00600'] = np.maximum(xdf['e00600'], xdf['e00650'])
     # constraint: e01500 >= e01700
     xdf['e01500'] = np.maximum(xdf['e01500'], xdf['e01700'])

--- a/taxcalc/validation/taxsim/prepare_taxcalc_input.py
+++ b/taxcalc/validation/taxsim/prepare_taxcalc_input.py
@@ -84,6 +84,7 @@ def translate(ivar):
     invar['f2441'] = ivar.loc[:, 8]
     invar['n24'] = ivar.loc[:, 9]
     num_eitc_qualified_kids = ivar.loc[:, 10]
+    # pylint: disable=assignment-from-no-return
     invar['EIC'] = np.minimum(num_eitc_qualified_kids, 3)
     num_taxpayers = np.where(mars == 2, 2, 1)
     invar['XTOT'] = num_taxpayers + num_deps


### PR DESCRIPTION
This pull request handles new warnings generated by upgrading to`pylint 2.2.2`.  Some of the new warnings were helpful at suggesting better coding style, but most were false negatives related to a long-standing (and apparently ongoing) difficulty with numpy functions.  The changes in this pull request do not involve any changes in tax logic or results.