### PR TITLE
Ensure that file/http names passed to read_json_param_objects end in '.json'

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1054,7 +1054,7 @@ class Calculator():
     def read_json_param_objects(reform, assump):
         """
         Read JSON reform and assump objects and
-        return a single dictionary containing 6 key:dict pairs:
+        return a single dictionary containing four key:dict pairs:
         'policy':dict, 'consumption':dict,
         'growdiff_baseline':dict, and 'growdiff_response':dict.
 
@@ -1100,8 +1100,14 @@ class Calculator():
             gdiff_resp_dict = dict()
         elif isinstance(assump, str):
             if os.path.isfile(assump):
+                if not assump.endswith('.json'):
+                    msg = "assump does not end with '.json': {}"
+                    raise ValueError(msg.format(assump))
                 txt = open(assump, 'r').read()
             elif assump.startswith('http'):
+                if not assump.endswith('.json'):
+                    msg = "assump does not end with '.json': {}"
+                    raise ValueError(msg.format(assump))
                 req = requests.get(assump)
                 req.raise_for_status()
                 txt = req.text
@@ -1117,8 +1123,14 @@ class Calculator():
             rpol_dict = dict()
         elif isinstance(reform, str):
             if os.path.isfile(reform):
+                if not reform.endswith('.json'):
+                    msg = "reform does not end with '.json': {}"
+                    raise ValueError(msg.format(reform))
                 txt = open(reform, 'r').read()
             elif reform.startswith('http'):
+                if not reform.endswith('.json'):
+                    msg = "reform does not end with '.json': {}"
+                    raise ValueError(msg.format(reform))
                 req = requests.get(reform)
                 req.raise_for_status()
                 txt = req.text

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -381,8 +381,6 @@ REFORM_JSON = """
 // the secondary keys are years.
 // Both the primary and secondary key values must be enclosed in quotes (").
 // Boolean variables are specified as true or false (no quotes; all lowercase).
-// Parameter code in the policy object is enclosed inside a pair of double
-// pipe characters (||).
 {
   "policy": {
     "_AMT_brk1": // top of first AMT tax bracket
@@ -481,6 +479,21 @@ def test_json_reform_url():
     params_str = Calculator.read_json_param_objects(reform_str, None)
     params_url = Calculator.read_json_param_objects(reform_url, None)
     assert params_str == params_url
+
+
+def test_bad_json_names(tests_path):
+    """
+    Test that ValueError raised with assump or reform do not end in '.json'
+    """
+    csvname = os.path.join(tests_path, '..', 'growfactors.csv')
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_objects(csvname, None)
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_objects('http://name.json.html', None)
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_objects(None, csvname)
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_objects(None, 'http://name.json.html')
 
 
 def test_read_bad_json_reform_file():


### PR DESCRIPTION
This pull request adds checks to the `Calculator.read_json_param_objects` static method that ensure any filename or string beginning with `http` ends with `.json`.  This error checking has been added in order to reduce the probability of the kind of confusion described in issue #2259.