### PR TITLE
Fix minor bugs associated with the new _SS_Earnings_thd policy parameter

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -649,7 +649,12 @@ class Calculator():
         # specify optional adjustment for employer (er) OASDI+HI payroll taxes
         mtr_on_earnings = variable_str in ('e00200p', 'e00200s')
         if wrt_full_compensation and mtr_on_earnings:
-            adj = np.where(variable < self.policy_param('SS_Earnings_c'),
+            # pylint: disable=assignment-from-no-return
+            oasdi_taxed = np.logical_or(
+                variable < self.policy_param('SS_Earnings_c'),
+                variable >= self.policy_param('SS_Earnings_thd')
+            )
+            adj = np.where(oasdi_taxed,
                            0.5 * (self.policy_param('FICA_ss_trt') +
                                   self.policy_param('FICA_mc_trt')),
                            0.5 * self.policy_param('FICA_mc_trt'))

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -601,8 +601,7 @@ class Parameters():
         Private method called only in the _update method.
         """
         # pylint: disable=assignment-from-none
-        wage_indexed = param_name in ('_SS_Earnings_c', '_SS_Earnings_thd')
-        if wage_indexed:
+        if param_name in ('_SS_Earnings_c', '_SS_Earnings_thd'):
             rates = self.wage_growth_rates()
         else:
             rates = self.inflation_rates()

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -56,7 +56,7 @@ class Parameters():
         """
         Return appropriate indexing rates for specified param_name.
         """
-        if param_name == '_SS_Earnings_c':
+        if param_name in ('_SS_Earnings_c', '_SS_Earnings_thd'):
             return self.wage_growth_rates()
         return self.inflation_rates()
 
@@ -79,7 +79,9 @@ class Parameters():
                     cpi_inflated = data.get('cpi_inflated', False)
                     if cpi_inflated:
                         index_rates = self.indexing_rates(name)
-                        if name != '_SS_Earnings_c':
+                        wage_indexed = name in ('_SS_Earnings_c',
+                                                '_SS_Earnings_thd')
+                        if not wage_indexed:
                             if known_years_is_int:
                                 values = values[:known_years]
                             else:
@@ -599,7 +601,8 @@ class Parameters():
         Private method called only in the _update method.
         """
         # pylint: disable=assignment-from-none
-        if param_name == '_SS_Earnings_c':
+        wage_indexed = param_name in ('_SS_Earnings_c', '_SS_Earnings_thd')
+        if wage_indexed:
             rates = self.wage_growth_rates()
         else:
             rates = self.inflation_rates()

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -55,7 +55,7 @@
 
     "_SS_Earnings_c": {
         "long_name": "Maximum taxable earnings (MTE) for Social Security",
-        "description": "Only individual earnings below this maximum amount are subjected to Social Security (OASDI) payroll tax.",
+        "description": "Individual earnings below this amount are subjected to Social Security (OASDI) payroll tax.",
         "section_1": "Payroll Taxes",
         "section_2": "Social Security FICA",
         "irs_ref": "W-2, Box 4, instructions",
@@ -88,7 +88,7 @@
 
     "_SS_Earnings_thd": {
         "long_name": "Additional Taxable Earnings Threshold for Social Security",
-        "description": "Wages and self-employment income above this threshold are subjected to Social Security (OASDI) payroll tax in addition to earnings below the maximum taxable earnings threshold.",
+        "description": "Individual earnings above this threshold are subjected to Social Security (OASDI) payroll tax, in addition to earnings below the maximum taxable earnings threshold.",
         "section_1": "Payroll Taxes",
         "section_2": "Social Security FICA",
         "irs_ref": "",

--- a/taxcalc/reforms/Larson2019.json
+++ b/taxcalc/reforms/Larson2019.json
@@ -1,6 +1,7 @@
 // Title: The Social Security 2100 Act: Rep. John Larson
 // Reform_File_Author: Anderson Frailey
 // Reform_Reference: https://larson.house.gov/social-security-2100
+// SSA Analysis: https://www.ssa.gov/OACT/solvency/LarsonBlumenthalVanHollen_20190130.pdf
 // Reform_Baseline: policy_current_law.json
 // Reform_Description:
 // - Raise threshold for Social Security benefit taxability to (1)

--- a/taxcalc/reforms/REFORMS.md
+++ b/taxcalc/reforms/REFORMS.md
@@ -23,6 +23,8 @@ documentation](https://PSLmodels.github.io/Tax-Calculator/index.html#pol).
 
 - [Larson Social Security 2100 Act](Larson2019.json)
 
+- [Sanders-DeFazio Social Security Expansion Act](SandersDeFazio.json)
+
 ## Tax Reforms Defined Relative to pre-TCJA Policy
 
 Read the answer to [Question 1 in this

--- a/taxcalc/reforms/SandersDeFazio.json
+++ b/taxcalc/reforms/SandersDeFazio.json
@@ -1,6 +1,7 @@
 // Title: Social Security Expansion Act: Sen. Bernie Sanders and Rep. Peter DeFazio
 // Reform_File_Author: Duncan Hobbs
 // Reform_Reference: https://defazio.house.gov/media-center/press-releases/defazio-sanders-introduce-legislation-to-strengthen-and-expand-social
+// SSA Analysis: https://www.ssa.gov/OACT/solvency/SandersDeFazio_20190213.pdf
 // Reform_Baseline: policy_current_law.json
 // Reform_Description:
 // - Apply the combined OASDI payroll tax rate on earnings above $250,000, effective 2020 (1)


### PR DESCRIPTION
Recently we added a new policy parameter, called `_SS_Earnings_thd`, to enable characterization of OASDI payroll tax reforms that tax earnings above a threshold (as well as tax earnings under a ceiling, as under current law).   Examples, of this kind of reform are the [Larson reform](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/reforms/Larson2019.json) and the [Sanders-DeFazio](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/reforms/SandersDeFazio.json) reform.

The code before this pull request produces correct estimates of those reforms' effect on payroll tax liabilities because those reforms propose that the `_SS_Earnings_thd` parameter is not indexed (that is, it is fixed in nominal terms).  However, users of Tax-Calculator might want to specify a reform that made this parameter be indexed.  This pull request indexes the `_SS_Earnings_thd` parameter using wages (not prices as for the income tax parameters), just as the `_SS_Earnings_c` parameter is wage indexed.  The SSA Office of the Chief Actuary's analyses of these the reforms confirms that, if indexed, this parameter would be wage (not price) indexed.

The code before this pull request produces incorrect MTRs on earnings for high-earnings individuals under these reforms when the `Calculator.mtr` method is called with its `wrt_full_compensation` argument equal to True, which is its default value.  Again, this bug would only affect MTR values (not payroll tax liabilities) for a few high-earners under these kinds of reforms.