### PR TITLE
Handle larger integer parameter values

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -520,7 +520,7 @@ class Parameters():
             elif x_type == 'boolean':
                 x = np.array(x, np.bool_)
             elif x_type == 'integer':
-                x = np.array(x, np.int8)
+                x = np.array(x, np.int16)
             elif x_type == 'string':
                 x = np.array(x, np.dtype(Parameters.STRING_DTYPE))
                 assert len(x.shape) == 1, \

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -359,7 +359,7 @@ def test_bool_int_value_info(tests_path, json_filename):
     path = os.path.join(tests_path, '..', json_filename)
     with open(path, 'r') as pfile:
         pdict = json.load(pfile)
-    maxint = np.iinfo(np.int8).max
+    maxint = np.iinfo(np.int16).max
     for param in sorted(pdict.keys()):
         # find param type based on value
         val = pdict[param]['value']


### PR DESCRIPTION
This pull request simply increases the size of each element in integer arrays holding parameters from `np.int8` to `np.int16`.