### PR TITLE
Make Consumption error handling be like Policy error handling

### DIFF
--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -21,6 +21,7 @@ def test_validity_of_consumption_vars_set():
 
 def test_update_consumption():
     consump = Consumption()
+    consump.ignore_update_errors()
     consump.update_consumption({})
     consump.update_consumption({2014: {'_MPC_e20400': [0.05],
                                        '_BEN_mcare_value': [0.75]},


### PR DESCRIPTION
This pull request enhances the Consumption class error-handling capabilities so they are the same as the error-handling capabilities of the Policy class.  These enhancements should make it easier for Tax-Brain to use the Consumption class, @andersonfrailey.