### PR TITLE
Make print_warnings default to True in all classes derived from Parameters class

### DIFF
--- a/docs/cookbook/recipe01.py
+++ b/docs/cookbook/recipe01.py
@@ -15,15 +15,18 @@ reform2_url = REFORMS_URL + reform2_name
 
 # specify Policy object for pre-TCJA policy
 bpolicy = Policy()
-bpolicy.implement_reform(reform1['policy'], print_warnings=False)
+bpolicy.implement_reform(reform1['policy'],
+                         print_warnings=False, raise_errors=False)
 assert not bpolicy.parameter_errors
 
 # specify Policy object for static analysis of reform relative to pre-TCJA
 reform2 = Calculator.read_json_param_objects(reform2_url, None)
 rpolicy = Policy()
-rpolicy.implement_reform(reform1['policy'], print_warnings=False)
+rpolicy.implement_reform(reform1['policy'],
+                         print_warnings=False, raise_errors=False)
 assert not rpolicy.parameter_errors
-rpolicy.implement_reform(reform2['policy'], print_warnings=False)
+rpolicy.implement_reform(reform2['policy'],
+                         print_warnings=False, raise_errors=False)
 assert not rpolicy.parameter_errors
 
 cyr = 2018

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -41,7 +41,7 @@ class Consumption(Parameters):
         self._ignore_errors = False
 
     def update_consumption(self, revision,
-                           print_warnings=False, raise_errors=True):
+                           print_warnings=True, raise_errors=True):
         """
         Update consumption for given revision, a dictionary consisting
         of one or more year:modification dictionaries.

--- a/taxcalc/growdiff.py
+++ b/taxcalc/growdiff.py
@@ -39,7 +39,7 @@ class GrowDiff(Parameters):
         self._ignore_errors = False
 
     def update_growdiff(self, revision,
-                        print_warnings=False, raise_errors=True):
+                        print_warnings=True, raise_errors=True):
         """
         Update growdiff default values using specified revision, which is
         a dictionary containing one or more year:modification dictionaries.

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -102,7 +102,7 @@ class Policy(Parameters):
         return self._wage_growth_rates
 
     def implement_reform(self, reform,
-                         print_warnings=False, raise_errors=True):
+                         print_warnings=True, raise_errors=True):
         """
         Implement multi-year policy reform and leave current_year unchanged.
 

--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -60,7 +60,7 @@ def fixture_test_reforms(tests_path):
     actfile_path = os.path.join(tests_path, 'reforms_actual.csv')
     afiles = os.path.join(tests_path, 'reform_actual_*.csv')
     wait_secs = 1
-    max_waits = 120
+    max_waits = 180
     # test_reforms setup
     if handling_logic:
         # remove reforms_actual.csv file if exists


### PR DESCRIPTION
This pull request changes the default value of the optional `print_warnings` argument to several methods: `Policy.implement_reform`, `Consumption.update_consumption`, and `GrowDiff.update_growdiff`.