### PR TITLE
Remove TaxBrain policy parameter suffix names, logic, and tests

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1142,11 +1142,7 @@ class Calculator():
                 txt = req.text
             else:
                 txt = reform
-            rpol_dict = (
-                Calculator._read_json_policy_reform_text(txt,
-                                                         gdiff_base_dict,
-                                                         gdiff_resp_dict)
-            )
+            rpol_dict = Calculator._read_json_policy_reform_text(txt)
         else:
             raise ValueError('reform is neither None nor string')
         # construct single composite dictionary
@@ -1462,9 +1458,7 @@ class Calculator():
         IITAX(self.__policy, self.__records)
 
     @staticmethod
-    def _read_json_policy_reform_text(text_string,
-                                      growdiff_baseline_dict,
-                                      growdiff_response_dict):
+    def _read_json_policy_reform_text(text_string):
         """
         Strip //-comments from text_string and return 1 dict based on the JSON.
 
@@ -1500,10 +1494,7 @@ class Calculator():
             msg = 'illegal key(s) "{}" in policy reform file'
             raise ValueError(msg.format(illegal_keys))
         # convert raw_dict['policy'] dictionary into prdict
-        tdict = Policy.translate_json_reform_suffixes(raw_dict['policy'],
-                                                      growdiff_baseline_dict,
-                                                      growdiff_response_dict)
-        prdict = Calculator._convert_parameter_dict(tdict)
+        prdict = Calculator._convert_parameter_dict(raw_dict['policy'])
         return prdict
 
     @staticmethod

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -38,7 +38,6 @@ class Consumption(Parameters):
                         Consumption.DEFAULT_NUM_YEARS)
         self.parameter_warnings = ''
         self.parameter_errors = ''
-        self._ignore_errors = False
 
     def update_consumption(self, revision,
                            print_warnings=True, raise_errors=True):
@@ -78,7 +77,7 @@ class Consumption(Parameters):
         self.parameter_warnings = ''
         self.parameter_errors = ''
         self._validate_names_types(revision)
-        if self.parameter_errors and not self._ignore_errors:
+        if self.parameter_errors:
             raise ValueError(self.parameter_errors)
         # implement the revision year by year
         revision_parameters = set()
@@ -131,9 +130,3 @@ class Consumption(Parameters):
         """
         return [getattr(self, 'BEN_{}_value'.format(var))
                 for var in Consumption.BENEFIT_VARS]
-
-    def ignore_update_errors(self):
-        """
-        Sets self._ignore_errors to True.
-        """
-        self._ignore_errors = True

--- a/taxcalc/growdiff.py
+++ b/taxcalc/growdiff.py
@@ -36,7 +36,6 @@ class GrowDiff(Parameters):
                         GrowDiff.DEFAULT_NUM_YEARS)
         self.parameter_warnings = ''
         self.parameter_errors = ''
-        self._ignore_errors = False
 
     def update_growdiff(self, revision,
                         print_warnings=True, raise_errors=True):
@@ -71,7 +70,7 @@ class GrowDiff(Parameters):
         self.parameter_warnings = ''
         self.parameter_errors = ''
         self._validate_names_types(revision)
-        if self.parameter_errors and not self._ignore_errors:
+        if self.parameter_errors:
             raise ValueError(self.parameter_errors)
         # implement the revision year by year
         revision_parameters = set()
@@ -99,12 +98,6 @@ class GrowDiff(Parameters):
                 if val != 0.0:
                     return True
         return False
-
-    def ignore_update_errors(self):
-        """
-        Sets self._ignore_errors to True.
-        """
-        self._ignore_errors = True
 
     def apply_to(self, growfactors):
         """

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -8,7 +8,6 @@ Tests of Calculator class.
 # pylint: disable=too-many-lines,invalid-name
 
 import os
-import json
 from io import StringIO
 import copy
 import pytest
@@ -702,147 +701,6 @@ def test_calc_all():
     assert calc.reform_warnings == ''
 
 
-def test_translate_json_reform_suffixes_mars_non_indexed():
-    """
-    Test read_json_param_objects method using MARS-indexed parameter suffixes.
-    """
-    json1 = """{"policy": {
-      "_II_em": {"2020": [20000], "2015": [15000]},
-      "_AMEDT_ec_joint": {"2018": [400000], "2016": [300000]},
-      "_AMEDT_ec_separate": {"2017": [150000], "2019": [200000]}
-    }}"""
-    pdict1 = Calculator.read_json_param_objects(reform=json1, assump=None)
-    rdict1 = pdict1['policy']
-    json2 = """{"policy": {
-      "_AMEDT_ec": {"2016": [[200000, 300000, 125000, 200000, 200000]],
-                    "2017": [[200000, 300000, 150000, 200000, 200000]],
-                    "2018": [[200000, 400000, 150000, 200000, 200000]],
-                    "2019": [[200000, 400000, 200000, 200000, 200000]]},
-      "_II_em": {"2015": [15000], "2020": [20000]}
-    }}"""
-    pdict2 = Calculator.read_json_param_objects(reform=json2, assump=None)
-    rdict2 = pdict2['policy']
-    assert len(rdict2) == len(rdict1)
-    for year in rdict2.keys():
-        if '_II_em' in rdict2[year].keys():
-            assert np.allclose(rdict1[year]['_II_em'],
-                               rdict2[year]['_II_em'],
-                               atol=0.01, rtol=0.0)
-        if '_AMEDT_ec' in rdict2[year].keys():
-            assert np.allclose(rdict1[year]['_AMEDT_ec'],
-                               rdict2[year]['_AMEDT_ec'],
-                               atol=0.01, rtol=0.0)
-
-
-def test_translate_json_reform_suffixes_eic():
-    """
-    Test read_json_param_objects method using EIC-indexed parameter suffixes.
-    """
-    json1 = """{"policy": {
-      "_II_em": {"2020": [20000], "2015": [15000]},
-      "_EITC_c_0kids": {"2018": [510], "2019": [510]},
-      "_EITC_c_1kid": {"2019": [3400], "2018": [3400]},
-      "_EITC_c_2kids": {"2018": [5616], "2019": [5616]},
-      "_EITC_c_3+kids": {"2019": [6318], "2018": [6318]}
-    }}"""
-    pdict1 = Calculator.read_json_param_objects(reform=json1, assump=None)
-    rdict1 = pdict1['policy']
-    json2 = """{"policy": {
-      "_EITC_c": {"2019": [[510, 3400, 5616, 6318]],
-                  "2018": [[510, 3400, 5616, 6318]]},
-      "_II_em": {"2020": [20000], "2015": [15000]}
-    }}"""
-    pdict2 = Calculator.read_json_param_objects(reform=json2, assump=None)
-    rdict2 = pdict2['policy']
-    assert len(rdict2) == len(rdict1)
-    for year in rdict2.keys():
-        if '_II_em' in rdict2[year].keys():
-            assert np.allclose(rdict1[year]['_II_em'],
-                               rdict2[year]['_II_em'],
-                               atol=0.01, rtol=0.0)
-        if '_EITC_c' in rdict2[year].keys():
-            assert np.allclose(rdict1[year]['_EITC_c'],
-                               rdict2[year]['_EITC_c'],
-                               atol=0.01, rtol=0.0)
-
-
-def test_translate_json_reform_suffixes_idedtype():
-    """
-    Test read_json_param_objects method using idedtype-indexed param suffixes.
-    """
-    # test read_json_param_objects(...)
-    # using idedtype-indexed parameter suffixes
-    json1 = """{"policy": {
-      "_ID_BenefitCap_rt": {"2019": [0.2]},
-      "_ID_BenefitCap_Switch_medical": {"2019": [false]},
-      "_ID_BenefitCap_Switch_casualty": {"2019": [false]},
-      "_ID_BenefitCap_Switch_misc": {"2019": [false]},
-      "_ID_BenefitCap_Switch_interest": {"2019": [false]},
-      "_ID_BenefitCap_Switch_charity": {"2019": [false]},
-      "_II_em": {"2020": [20000], "2015": [15000]}
-    }}"""
-    pdict1 = Calculator.read_json_param_objects(reform=json1, assump=None)
-    rdict1 = pdict1['policy']
-    json2 = """{"policy": {
-      "_II_em": {"2020": [20000], "2015": [15000]},
-      "_ID_BenefitCap_Switch": {
-        "2019": [[false, true, true, false, false, false, false]]
-      },
-      "_ID_BenefitCap_rt": {"2019": [0.2]}
-    }}"""
-    pdict2 = Calculator.read_json_param_objects(reform=json2, assump=None)
-    rdict2 = pdict2['policy']
-    assert len(rdict2) == len(rdict1)
-    for year in rdict2.keys():
-        if '_II_em' in rdict2[year].keys():
-            assert np.allclose(rdict1[year]['_II_em'],
-                               rdict2[year]['_II_em'],
-                               atol=0.01, rtol=0.0)
-        if '_ID_BenefitCap_rt' in rdict2[year].keys():
-            assert np.allclose(rdict1[year]['_ID_BenefitCap_rt'],
-                               rdict2[year]['_ID_BenefitCap_rt'],
-                               atol=0.01, rtol=0.0)
-        if '_ID_BenefitCap_Switch' in rdict2[year].keys():
-            assert np.allclose(rdict1[year]['_ID_BenefitCap_Switch'],
-                               rdict2[year]['_ID_BenefitCap_Switch'],
-                               atol=0.01, rtol=0.0)
-
-
-def test_read_json_param_with_suffixes_and_errors():
-    """
-    Test interaction of policy parameter suffixes and reform errors
-    (fails without 0.10.2 bug fix as reported by Hank Doupe in PB PR#641)
-    """
-    reform = {
-        u'policy': {
-            u'_II_brk4_separate': {u'2017': [5000.0]},
-            u'_STD_separate': {u'2017': [8000.0]},
-            u'_STD_single': {u'2018': [1000.0]},
-            u'_II_brk2_headhousehold': {u'2017': [1000.0]},
-            u'_II_brk4_single': {u'2017': [500.0]},
-            u'_STD_joint': {u'2017': [10000.0], u'2020': [150.0]},
-            u'_II_brk2_separate': {u'2017': [1000.0]},
-            u'_II_brk2_single': {u'2017': [1000.0]},
-            u'_II_brk2_joint': {u'2017': [1000.0]},
-            u'_FICA_ss_trt': {u'2017': [-1.0], u'2019': [0.1]},
-            u'_II_brk4_headhousehold': {u'2017': [500.0]},
-            u'_STD_headhousehold': {u'2017': [10000.0], u'2020': [150.0]},
-            u'_ID_Medical_frt': {u'2019': [0.06]},
-            u'_II_brk4_joint': {u'2017': [500.0]},
-            u'_ID_BenefitSurtax_Switch_medical': {u'2017': [True]}
-        }
-    }
-    json_reform = json.dumps(reform)
-    params = Calculator.read_json_param_objects(json_reform, None)
-    assert isinstance(params, dict)
-    pol = Policy()
-    pol.ignore_reform_errors()
-    pol.implement_reform(params['policy'],
-                         print_warnings=False, raise_errors=False)
-    assert pol.parameter_errors
-    assert pol.parameter_warnings
-
-
 def test_noreform_documentation():
     """
     Test automatic documentation creation.
@@ -877,34 +735,42 @@ def test_reform_documentation():
     Test automatic documentation creation.
     """
     reform_json = """
-    {
-    "policy": {
-      "_II_em_cpi": {"2016": false,
-                     "2018": true},
-      "_II_em": {"2016": [5000],
-                 "2018": [6000],
-                 "2020": [7000]},
-      "_EITC_indiv": {"2017": [true]},
-      "_STD_Aged_cpi": {"2016": false},
-      "_STD_Aged": {"2016": [[1600, 1300, 1300, 1600, 1600]],
-                    "2020": [[2000, 2000, 2000, 2000, 2000]]},
-      "_ID_BenefitCap_Switch_medical": {"2020": [false]},
-      "_ID_BenefitCap_Switch_casualty": {"2020": [false]},
-      "_ID_BenefitCap_Switch_misc": {"2020": [false]},
-      "_ID_BenefitCap_Switch_interest": {"2020": [false]},
-      "_ID_BenefitCap_Switch_charity": {"2020": [false]}
-      }
+{
+"policy": {
+    "_II_em_cpi": {
+        "2016": false,
+        "2018": true
+    },
+    "_II_em": {
+        "2016": [5000],
+        "2018": [6000],
+        "2020": [7000]
+    },
+    "_EITC_indiv": {
+        "2017": [true]
+    },
+    "_STD_Aged_cpi": {
+        "2016": false
+    },
+    "_STD_Aged": {
+        "2016": [[1600, 1300, 1300, 1600, 1600]],
+        "2020": [[2000, 2000, 2000, 2000, 2000]]
+    },
+    "_ID_BenefitCap_Switch": {
+        "2020": [[false, false, false, false, false, false, false]]
     }
-    """
+}
+}
+"""
     assump_json = """
-    {
-    "consumption": {},
-    // increase baseline inflation rate by one percentage point in 2014+
-    // (has no effect on known policy parameter values)
-    "growdiff_baseline": {"_ACPIU": {"2014": [0.01]}},
-    "growdiff_response": {}
-    }
-    """
+{
+"consumption": {},
+// increase baseline inflation rate by one percentage point in 2014+
+// (has no effect on known policy parameter values)
+"growdiff_baseline": {"_ACPIU": {"2014": [0.01]}},
+"growdiff_response": {}
+}
+"""
     params = Calculator.read_json_param_objects(reform_json, assump_json)
     assert isinstance(params, dict)
     doc = Calculator.reform_documentation(params)

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -21,7 +21,6 @@ def test_validity_of_consumption_vars_set():
 
 def test_update_consumption():
     consump = Consumption()
-    consump.ignore_update_errors()
     consump.update_consumption({})
     consump.update_consumption({2014: {'_MPC_e20400': [0.05],
                                        '_BEN_mcare_value': [0.75]},

--- a/taxcalc/tests/test_growdiff.py
+++ b/taxcalc/tests/test_growdiff.py
@@ -15,7 +15,6 @@ def test_year_consistency():
 
 def test_update_and_apply_growdiff():
     gdiff = GrowDiff()
-    gdiff.ignore_update_errors()
     # update GrowDiff instance
     diffs = {2014: {'_AWAGE': [0.01]},
              2016: {'_AWAGE': [0.02]}}

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -772,33 +772,6 @@ def test_section_titles(tests_path):
             assert sec2title in htmxdict[sec1title]
 
 
-def test_json_reform_suffixes(tests_path):
-    """
-    Check "var_label" values versus Policy.JSON_REFORM_SUFFIXES set
-    """
-    # read policy_current_law.json file into a dictionary
-    path = os.path.join(tests_path, '..', 'policy_current_law.json')
-    with open(path, 'r') as clpfile:
-        clpdict = json.load(clpfile)
-    # create set of suffixes in the clpdict "col_label" lists
-    json_suffixes = Policy.JSON_REFORM_SUFFIXES.keys()
-    clp_suffixes = set()
-    for param in clpdict:
-        suffix = param.split('_')[-1]
-        assert suffix not in json_suffixes
-        col_var = clpdict[param]['col_var']
-        col_label = clpdict[param]['col_label']
-        if col_var == '':
-            assert col_label == ''
-            continue
-        assert isinstance(col_label, list)
-        clp_suffixes.update(col_label)
-    # check that suffixes set is same as Policy.JSON_REFORM_SUFFIXES set
-    unmatched = clp_suffixes ^ set(json_suffixes)
-    if unmatched:
-        assert unmatched == 'UNMATCHED SUFFIXES'
-
-
 def test_description_punctuation(tests_path):
     """
     Check that each description ends in a period.
@@ -942,15 +915,6 @@ def test_validate_param_names_types_errors():
     with pytest.raises(ValueError):
         pol.implement_reform(ref)
     del pol
-    # this test was contributed by Hank Doupe in bug report #1980
-    json_reform = """
-    {"policy": {"_ID_BenefitSurtax_Switch_medical": {"2018": [true]}}}
-    """
-    pdict = Calculator.read_json_param_objects(json_reform, None)
-    pol = Policy()
-    pol.implement_reform(pdict["policy"], raise_errors=False)
-    assert pol.parameter_errors == ''
-    del pol
     # this test checks "is a removed parameter" error for base parameter
     pol = Policy()
     ref = {2019: {'_DependentCredit_Child_c': [400]}}
@@ -986,10 +950,9 @@ def test_validate_param_values_warnings_errors():
     pol4.implement_reform(ref4, print_warnings=False, raise_errors=False)
     assert pol4.parameter_errors
     pol5 = Policy()
-    pol5.ignore_reform_errors()
     ref5 = {2025: {'_ID_BenefitSurtax_Switch': [[False, True, 0, 1, 0, 1, 0]]}}
-    pol5.implement_reform(ref5, print_warnings=False, raise_errors=False)
-    assert pol5.parameter_errors
+    with pytest.raises(ValueError):
+        pol5.implement_reform(ref5, print_warnings=False, raise_errors=False)
     pol6 = Policy()
     ref6 = {2013: {'_STD': [[20000, 25000, 20000, 20000, 25000]]}}
     pol6.implement_reform(ref6, print_warnings=False, raise_errors=False)


### PR DESCRIPTION
The new Tax-Brain repository now has responsibility for providing an interface for the TaxBrain web app.
The functionality of the code removed in this pull request should be moved to Tax-Brain because it is used only by the TaxBrain web app.