### PR TITLE
 Change yaml.load(input) to yaml.safe_load(input)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,3 @@ markers =
     benefits
     itmded_vars
     pep8
-    one

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ markers =
     benefits
     itmded_vars
     pep8
+    one

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -24,7 +24,7 @@ def test_for_package_existence():
     if re.search('taxcalc', envless_out) is not None:
         assert 'taxcalc package' == 'installed'
 
-@pytest.mark.one
+
 def test_for_consistency(tests_path):
     """
     Ensure that there is consistency between environment.yml dependencies

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -24,7 +24,7 @@ def test_for_package_existence():
     if re.search('taxcalc', envless_out) is not None:
         assert 'taxcalc package' == 'installed'
 
-
+@pytest.mark.one
 def test_for_consistency(tests_path):
     """
     Ensure that there is consistency between environment.yml dependencies
@@ -42,7 +42,7 @@ def test_for_consistency(tests_path):
     meta_file = os.path.join(tests_path, '..', '..',
                              'conda.recipe', 'meta.yaml')
     with open(meta_file, 'r') as stream:
-        meta = yaml.load(stream)
+        meta = yaml.safe_load(stream)
     bld = set(meta['requirements']['build'])
     run = set(meta['requirements']['run'])
     # confirm conda.recipe/meta.yaml build and run requirements are the same
@@ -51,7 +51,7 @@ def test_for_consistency(tests_path):
     envr_file = os.path.join(tests_path, '..', '..',
                              'environment.yml')
     with open(envr_file, 'r') as stream:
-        envr = yaml.load(stream)
+        envr = yaml.safe_load(stream)
     env = set(envr['dependencies'])
     # confirm that extras in env (relative to run) equal the dev_pkgs set
     extras = env - run


### PR DESCRIPTION
Eliminates pytest warning when using PyYAML release 5.1.