### PR TITLE
Remove obsolete "pylint: disable=..." comments and work around others

### DIFF
--- a/docs/make_uguide.py
+++ b/docs/make_uguide.py
@@ -68,20 +68,20 @@ def policy_param_text(pname, param):
     """
     Extract info from param for pname and return as HTML string.
     """
-    # pylint: disable=too-many-statements,too-many-branches,len-as-condition
+    # pylint: disable=too-many-statements,too-many-branches
     sec1 = param['section_1']
-    if len(sec1) > 0:
+    if sec1:
         txt = '<p><b>{} &mdash; {}</b>'.format(sec1, param['section_2'])
     else:
         txt = '<p><b>{} &mdash; {}</b>'.format('Other Parameters',
                                                'Not in Tax-Brain webapp')
     txt += '<br><i>tc Name:</i> {}'.format(pname)
-    if len(sec1) > 0:
+    if sec1:
         txt += '<br><i>TB Name:</i> {}'.format(param['long_name'])
     else:
         txt += '<br><i>Long Name:</i> {}'.format(param['long_name'])
     txt += '<br><i>Description:</i> {}'.format(param['description'])
-    if len(param.get('notes', '')) > 0:
+    if param.get('notes', ''):
         txt += '<br><i>Notes:</i> {}'.format(param['notes'])
     txt += '<br><i>Has An Effect When Using:</i>'
     txt += '&nbsp;&nbsp; <i>PUF data:</i> '
@@ -106,7 +106,7 @@ def policy_param_text(pname, param):
         txt += 'False'
     txt += '<br><i>Value Type:</i> {}'.format(param['value_type'])
     txt += '<br><i>Known Values:</i>'
-    if len(param.get('vi_vals', [])) > 0:
+    if param.get('vi_vals', []):
         cols = ', '.join(param['vi_vals'])
         txt += '<br>&nbsp;&nbsp; for: [{}]'.format(cols)
     for cyr, val in zip(param['value_yrs'], param['value']):
@@ -224,24 +224,23 @@ def assumption_param_text(pname, ptype, param):
     """
     Extract info from param for pname of ptype and return as HTML string.
     """
-    # pylint: disable=len-as-condition
     sec1 = param.get('section_1', '')
-    if len(sec1) > 0:
+    if sec1:
         txt = '<p><b>{} &mdash; {}</b>'.format(sec1,
                                                param.get('section_2', ''))
     else:
         txt = '<p><b>{} &mdash; {}</b>'.format('Assumption Parameter',
                                                ptype.capitalize())
     txt += '<br><i>tc Name:</i> {}'.format(pname)
-    if len(sec1) > 0:
+    if sec1:
         txt += '<br><i>TB Name:</i> {}'.format(param['long_name'])
     else:
         txt += '<br><i>Long Name:</i> {}'.format(param['long_name'])
     txt += '<br><i>Description:</i> {}'.format(param['description'])
-    if len(param.get('notes', '')) > 0:
+    if param.get('notes', ''):
         txt += '<br><i>Notes:</i> {}'.format(param['notes'])
     txt += '<br><i>Default Value:</i>'
-    if len(param.get('vi_vals', [])) > 0:
+    if param.get('vi_vals', []):
         cols = ', '.join(param['vi_vals'])
         txt += '<br>&nbsp;&nbsp; for: [{}]'.format(cols)
     for cyr, val in zip(param['value_yrs'], param['value']):

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -1785,7 +1785,6 @@ def BenefitLimitation(calc):
         benefit_limit = deduct_exps * calc.policy_param('ID_BenefitCap_rt')
         # Add the difference between the actual benefit and capped benefit
         # to income tax and combined tax liabilities.
-        # pylint: disable=assignment-from-no-return
         excess_benefit = np.maximum(benefit - benefit_limit, 0)
         calc.incarray('iitax', excess_benefit)
         calc.incarray('surtax', excess_benefit)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -5,7 +5,7 @@ Tax-Calculator federal income and payroll tax Calculator class.
 # pycodestyle calculator.py
 # pylint --disable=locally-disabled calculator.py
 #
-# pylint: disable=invalid-name,no-value-for-parameter,too-many-lines
+# pylint: disable=too-many-lines,no-value-for-parameter
 
 import copy
 import numpy as np
@@ -637,7 +637,7 @@ class Calculator():
         elif variable_str == 'e00650':
             divincome_var = self.array('e00600')
         elif variable_str == 'e26270':
-            schEincome_var = self.array('e02000')
+            scheincome_var = self.array('e02000')
         # calculate level of taxes after a marginal increase in income
         self.array(variable_str, variable + finite_diff)
         if variable_str == 'e00200p':
@@ -649,7 +649,7 @@ class Calculator():
         elif variable_str == 'e00650':
             self.array('e00600', divincome_var + finite_diff)
         elif variable_str == 'e26270':
-            self.array('e02000', schEincome_var + finite_diff)
+            self.array('e02000', scheincome_var + finite_diff)
         if self.__consumption.has_response():
             self.__consumption.response(self.__records, finite_diff)
         self.calc_all(zero_out_calc_vars=zero_out_calculated_vars)
@@ -670,7 +670,6 @@ class Calculator():
         # specify optional adjustment for employer (er) OASDI+HI payroll taxes
         mtr_on_earnings = variable_str in ('e00200p', 'e00200s')
         if wrt_full_compensation and mtr_on_earnings:
-            # pylint: disable=assignment-from-no-return
             oasdi_taxed = np.logical_or(
                 variable < self.policy_param('SS_Earnings_c'),
                 variable >= self.policy_param('SS_Earnings_thd')
@@ -700,7 +699,7 @@ class Calculator():
         elif variable_str == 'e00650':
             del divincome_var
         elif variable_str == 'e26270':
-            del schEincome_var
+            del scheincome_var
         del payrolltax_chng
         del incometax_chng
         del combined_taxes_chng

--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -74,8 +74,7 @@ class GrowFactors():
         self._last_year = max(gfdf.index)
         # set gfdf as attribute of class
         self.gfdf = pd.DataFrame()
-        setattr(self, 'gfdf',
-                gfdf.astype(np.float64))  # pylint: disable=no-member
+        setattr(self, 'gfdf', gfdf.astype(np.float64))
         del gfdf
         # specify factors as being unused (that is, not yet accessed)
         self.used = False
@@ -108,7 +107,6 @@ class GrowFactors():
         if lastyear > self.last_year:
             msg = 'last_year={} > GrowFactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
-        # pylint: disable=no-member
         rates = [round((self.gfdf['ACPIU'][cyr] - 1.0), 4)
                  for cyr in range(firstyear, lastyear + 1)]
         return rates
@@ -127,7 +125,6 @@ class GrowFactors():
         if lastyear > self.last_year:
             msg = 'lastyear={} > GrowFactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
-        # pylint: disable=no-member
         rates = [round((self.gfdf['AWAGE'][cyr] - 1.0), 4)
                  for cyr in range(firstyear, lastyear + 1)]
         return rates

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -5,7 +5,7 @@ Tax-Calculator abstract base parameters class.
 # pycodestyle parameters.py
 # pylint --disable=locally-disabled parameters.py
 #
-# pylint: disable=attribute-defined-outside-init,no-member
+# pylixx: disable=attribute-defined-outside-init
 
 import os
 import re
@@ -47,6 +47,19 @@ class Parameters():
         for pname in vals:
             self._vals['_' + pname] = vals[pname]
         del vals
+        # declare several scalar variables
+        self._current_year = 0
+        self._start_year = 0
+        self._end_year = 0
+        self._num_years = 0
+        self._last_known_year = 0
+        # declare optional _inflation_rates and _wage_growth_rates
+        self._inflation_rates = list()
+        self._wage_growth_rates = list()
+        self._wage_indexed = None
+        # declare removed and redefined parameters
+        self._removed = None
+        self._redefined = None
         # declare parameter warning/error variables
         self.parameter_warnings = ''
         self.parameter_errors = ''
@@ -96,15 +109,13 @@ class Parameters():
         """
         Override this method in subclass when appropriate.
         """
-        # pylint: disable=no-self-use
-        return None
+        return self._inflation_rates
 
     def wage_growth_rates(self):
         """
         Override this method in subclass when appropriate.
         """
-        # pylint: disable=no-self-use
-        return None
+        return self._wage_growth_rates
 
     @property
     def num_years(self):
@@ -221,7 +232,6 @@ class Parameters():
             valtype = data['value_type']
             values = data['value']
             indexed = data.get('indexed', False)
-            # pylint: disable=assignment-from-none
             if indexed:
                 if name in self._wage_indexed:
                     index_rates = self.wage_growth_rates()
@@ -734,7 +744,6 @@ class Parameters():
         """
         Private method called only by the private Parameter._update method.
         """
-        # pylint: disable=assignment-from-none
         if param_is_wage_indexed:
             rates = self.wage_growth_rates()
         else:

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -628,21 +628,19 @@ class Parameters():
 
     STRING_DTYPE = 'U16'
 
-    # pylint: disable=invalid-name
-
     @staticmethod
-    def _expand_array(x, x_type, inflate, inflation_rates, num_years):
+    def _expand_array(xxx, xxx_type, inflate, inflation_rates, num_years):
         """
         Private method called only within this abstract base class.
-        Dispatch to either _expand_1d or _expand_2d given dimension of x.
+        Dispatch to either _expand_1d or _expand_2d given dimension of xxx.
 
         Parameters
         ----------
-        x : value to expand
-            x must be either a scalar list or a 1D numpy array, or
-            x must be either a list of scalar lists or a 2D numpy array
+        xxx : value to expand
+              xxx must be either a scalar list or a 1D numpy array, or
+              xxx must be either a list of scalar lists or a 2D numpy array
 
-        x_type : string ('boolean', 'integer', 'real', 'string')
+        xxx_type : string ('real', 'boolean', 'integer', 'string')
 
         inflate: boolean
             As we expand, inflate values if this is True, otherwise, just copy
@@ -657,64 +655,64 @@ class Parameters():
         -------
         expanded numpy array with specified type
         """
-        assert isinstance(x, (list, np.ndarray))
-        if isinstance(x, list):
-            if x_type == 'real':
-                x = np.array(x, np.float64)
-            elif x_type == 'boolean':
-                x = np.array(x, np.bool_)
-            elif x_type == 'integer':
-                x = np.array(x, np.int16)
-            elif x_type == 'string':
-                x = np.array(x, np.dtype(Parameters.STRING_DTYPE))
-                assert len(x.shape) == 1, \
+        assert isinstance(xxx, (list, np.ndarray))
+        if isinstance(xxx, list):
+            if xxx_type == 'real':
+                xxx = np.array(xxx, np.float64)
+            elif xxx_type == 'boolean':
+                xxx = np.array(xxx, np.bool_)
+            elif xxx_type == 'integer':
+                xxx = np.array(xxx, np.int16)
+            elif xxx_type == 'string':
+                xxx = np.array(xxx, np.dtype(Parameters.STRING_DTYPE))
+                assert len(xxx.shape) == 1, \
                     'string parameters must be scalar (not vector)'
-        dim = len(x.shape)
+        dim = len(xxx.shape)
         assert dim in (1, 2)
         if dim == 1:
-            return Parameters._expand_1d(x, inflate, inflation_rates,
+            return Parameters._expand_1d(xxx, inflate, inflation_rates,
                                          num_years)
-        return Parameters._expand_2d(x, inflate, inflation_rates,
+        return Parameters._expand_2d(xxx, inflate, inflation_rates,
                                      num_years)
 
     @staticmethod
-    def _expand_1d(x, inflate, inflation_rates, num_years):
+    def _expand_1d(xxx, inflate, inflation_rates, num_years):
         """
         Private method called only from _expand_array method.
-        Expand the given data x to account for given number of budget years.
+        Expand the given data xxx to account for given number of budget years.
         If necessary, pad out additional years by increasing the last given
         year using the given inflation_rates list.
         """
-        if not isinstance(x, np.ndarray):
-            raise ValueError('_expand_1d expects x to be a numpy array')
-        if len(x) >= num_years:
-            return x
-        string_type = x.dtype == Parameters.STRING_DTYPE
+        if not isinstance(xxx, np.ndarray):
+            raise ValueError('_expand_1d expects xxx to be a numpy array')
+        if len(xxx) >= num_years:
+            return xxx
+        string_type = xxx.dtype == Parameters.STRING_DTYPE
         if string_type:
             ans = np.array(['' for i in range(0, num_years)],
-                           dtype=x.dtype)
+                           dtype=xxx.dtype)
         else:
-            ans = np.zeros(num_years, dtype=x.dtype)
-        ans[:len(x)] = x
+            ans = np.zeros(num_years, dtype=xxx.dtype)
+        ans[:len(xxx)] = xxx
         if string_type:
-            extra = [str(x[-1]) for i in
-                     range(1, num_years - len(x) + 1)]
+            extra = [str(xxx[-1]) for i in
+                     range(1, num_years - len(xxx) + 1)]
         else:
             if inflate:
                 extra = []
-                cur = x[-1]
-                for i in range(0, num_years - len(x)):
-                    cur *= (1. + inflation_rates[i + len(x) - 1])
+                cur = xxx[-1]
+                for i in range(0, num_years - len(xxx)):
+                    cur *= (1. + inflation_rates[i + len(xxx) - 1])
                     cur = round(cur, 2) if cur < 9e99 else 9e99
                     extra.append(cur)
             else:
-                extra = [float(x[-1]) for i in
-                         range(1, num_years - len(x) + 1)]
-        ans[len(x):] = extra
+                extra = [float(xxx[-1]) for i in
+                         range(1, num_years - len(xxx) + 1)]
+        ans[len(xxx):] = extra
         return ans
 
     @staticmethod
-    def _expand_2d(x, inflate, inflation_rates, num_years):
+    def _expand_2d(xxx, inflate, inflation_rates, num_years):
         """
         Private method called only from _expand_array method.
         Expand the given data to account for the given number of budget years.
@@ -722,13 +720,13 @@ class Parameters():
         number of rows. For each expanded row, we inflate using the given
         inflation rates list.
         """
-        if not isinstance(x, np.ndarray):
-            raise ValueError('_expand_2d expects x to be a numpy array')
-        if x.shape[0] >= num_years:
-            return x
-        ans = np.zeros((num_years, x.shape[1]), dtype=x.dtype)
-        ans[:len(x), :] = x
-        for i in range(x.shape[0], ans.shape[0]):
+        if not isinstance(xxx, np.ndarray):
+            raise ValueError('_expand_2d expects xxx to be a numpy array')
+        if xxx.shape[0] >= num_years:
+            return xxx
+        ans = np.zeros((num_years, xxx.shape[1]), dtype=xxx.dtype)
+        ans[:len(xxx), :] = xxx
+        for i in range(xxx.shape[0], ans.shape[0]):
             for j in range(ans.shape[1]):
                 if inflate:
                     cur = (ans[i - 1, j] *

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -140,7 +140,6 @@ class Records():
         if not np.allclose(self.e02100s[nospouse], zeros):
             raise ValueError(msg.format('e02100s'))
         # check that ordinary dividends are no less than qualified dividends
-        # pylint: disable=assignment-from-no-return
         other_dividends = np.maximum(0., self.e00600 - self.e00650)
         if not np.allclose(self.e00600, self.e00650 + other_dividends,
                            rtol=0.0, atol=tol):

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -112,8 +112,8 @@ def test_params_class(revision, expect, params_json_file):
         assert prms.start_year == 2001
         assert prms.current_year == 2001
         assert prms.end_year == 2010
-        assert prms.inflation_rates() is None
-        assert prms.wage_growth_rates() is None
+        assert prms.inflation_rates() == list()
+        assert prms.wage_growth_rates() == list()
         prms.set_year(2010)
         assert prms.current_year == 2010
         with pytest.raises(ValueError):

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -147,7 +147,7 @@ def test_read_json_reform_file_and_implement_reform(set_year):
         pol.set_year(2015)
     pol.implement_reform(Policy.read_json_reform(REFORM_JSON))
     syr = pol.start_year
-    # pylint: disable=protected-access,no-member
+    # pylint: disable=protected-access
     amt_brk1 = pol._AMT_brk1
     assert amt_brk1[2015 - syr] == 200000
     assert amt_brk1[2016 - syr] > 200000

--- a/taxcalc/tests/test_responses.py
+++ b/taxcalc/tests/test_responses.py
@@ -7,7 +7,6 @@ Test example JSON response assumption files in taxcalc/responses directory
 
 import os
 import glob
-import pytest  # pylint: disable=unused-import
 # pylint: disable=import-error
 from taxcalc import Consumption, GrowDiff
 

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -5,7 +5,7 @@ Tests of Tax-Calculator utility functions.
 # pycodestyle test_utils.py
 # pylint --disable=locally-disabled test_utils.py
 #
-# pylint: disable=missing-docstring,no-member,protected-access,too-many-lines
+# pylint: disable=missing-docstring
 
 import os
 import math

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -216,7 +216,7 @@ def add_quantile_table_row_variable(dframe, income_measure, num_quantiles,
         assert bin_edges[1] > 1e-9  # bin_edges[1] is top of bottom decile
         neg_im = np.less_equal(dframe[income_measure], -1e-9)
         neg_wght = dframe['s006'][neg_im].sum()
-        zer_im = np.logical_and(  # pylint: disable=assignment-from-no-return
+        zer_im = np.logical_and(
             np.greater(dframe[income_measure], -1e-9),
             np.less(dframe[income_measure], 1e-9)
         )
@@ -373,7 +373,6 @@ def create_distribution_table(vdf, groupby, income_measure,
         topdec_row = get_sums(dist_table[11:lenindex])[dist_table.columns]
         # move top-decile detail rows to make room for topdec_row and sum_row
         dist_table = dist_table.reindex(index=range(0, lenindex + 2))
-        # pylint: disable=no-member
         dist_table.iloc[15] = dist_table.iloc[13]
         dist_table.iloc[14] = dist_table.iloc[12]
         dist_table.iloc[13] = dist_table.iloc[11]
@@ -548,7 +547,6 @@ def create_difference_table(vdf1, vdf2, groupby, tax_to_diff,
         topdec_row = get_sums(diff_table[11:lenindex])[diff_table.columns]
         # move top-decile detail rows to make room for topdec_row and sum_row
         diff_table = diff_table.reindex(index=range(0, lenindex + 2))
-        # pylint: disable=no-member
         diff_table.iloc[15] = diff_table.iloc[13]
         diff_table.iloc[14] = diff_table.iloc[12]
         diff_table.iloc[13] = diff_table.iloc[11]
@@ -1004,10 +1002,9 @@ def atr_graph_data(vdf, year,
     avgtax1_series = gdfx.apply(weighted_mean, 'tax1')
     avgtax2_series = gdfx.apply(weighted_mean, 'tax2')
     # compute average tax rates for each included income percentile
-    # pylint: disable=unsupported-assignment-operation
-    atr1_series = np.zeros_like(avginc_series)
+    atr1_series = np.zeros(avginc_series.shape)
     atr1_series[included] = avgtax1_series[included] / avginc_series[included]
-    atr2_series = np.zeros_like(avginc_series)
+    atr2_series = np.zeros(avginc_series.shape)
     atr2_series[included] = avgtax2_series[included] / avginc_series[included]
     # construct DataFrame containing the two atr?_series
     lines = pd.DataFrame()
@@ -1172,8 +1169,7 @@ def pch_graph_data(vdf, year, pop_quantiles=False):
     avginc_series = gdfx.apply(weighted_mean, 'expanded_income')
     change_series = gdfx.apply(weighted_mean, 'chg_aftinc')
     # compute percentage change statistic each included income percentile
-    # pylint: disable=unsupported-assignment-operation
-    pch_series = np.zeros_like(avginc_series)
+    pch_series = np.zeros(avginc_series.shape)
     pch_series[included] = change_series[included] / avginc_series[included]
     # construct DataFrame containing the pch_series expressed as percent
     line = pd.DataFrame()
@@ -1428,13 +1424,9 @@ def ce_aftertax_expanded_income(df1, df2,
     cedict['inc1'] = weighted_sum(df1, 'expanded_income') * billion
     cedict['inc2'] = weighted_sum(df2, 'expanded_income') * billion
     # calculate sample-weighted probability of each filing unit
-    prob_raw = np.divide(  # pylint: disable=assignment-from-no-return
-        df1['s006'], df1['s006'].sum()
-    )
+    prob_raw = np.divide(df1['s006'], df1['s006'].sum())
     # handle any rounding error in probability calculation
-    prob = np.divide(  # pylint: disable=assignment-from-no-return
-        prob_raw, prob_raw.sum()
-    )
+    prob = np.divide(prob_raw, prob_raw.sum())
     # calculate after-tax income of each filing unit in df1 and df2
     ati1 = df1['expanded_income'] - df1['combined']
     ati2 = df2['expanded_income'] - df2['combined']
@@ -1512,10 +1504,9 @@ def bootstrap_se_ci(data, seed, num_samples, statistic, alpha):
     assert isinstance(alpha, float)
     bsest = dict()
     bsest['seed'] = seed
-    np.random.seed(seed)  # pylint: disable=no-member
+    np.random.seed(seed)
     dlen = len(data)
-    idx = np.random.randint(low=0, high=dlen,   # pylint: disable=no-member
-                            size=(num_samples, dlen))
+    idx = np.random.randint(low=0, high=dlen, size=(num_samples, dlen))
     samples = data[idx]
     stat = statistic(samples, axis=1)
     bsest['B'] = num_samples

--- a/taxcalc/validation/csv_taxdiffs.py
+++ b/taxcalc/validation/csv_taxdiffs.py
@@ -27,7 +27,7 @@ def main(file1name, file2name, rounding_error):
     if 'INCTAX' in list(df1):
         # rename minimal tc OUTPUT variables to --dump OUTPUT variable names
         minimalout1 = True
-        df1.rename(index=str,  # pylint: disable=no-member
+        df1.rename(index=str,
                    columns={'INCTAX': 'iitax', 'PAYTAX': 'payrolltax'},
                    inplace=True)
     else:
@@ -38,7 +38,7 @@ def main(file1name, file2name, rounding_error):
     if 'INCTAX' in list(df2):
         # rename minimal tc OUTPUT variables to --dump OUTPUT variable names
         minimalout2 = True
-        df2.rename(index=str,  # pylint: disable=no-member
+        df2.rename(index=str,
                    columns={'INCTAX': 'iitax', 'PAYTAX': 'payrolltax'},
                    inplace=True)
     else:

--- a/taxcalc/validation/puf_fuzz.py
+++ b/taxcalc/validation/puf_fuzz.py
@@ -67,8 +67,6 @@ def randomize_data(xdf, taxyear, rnseed):
     rnseed: integer
         specifies random-number seed to use in the randomization.
     """
-    # pylint: disable=no-member
-    # (above pylint comment eliminates several bogus np warnings)
     xdf['FLPDYR'] = taxyear
     num = xdf['FLPDYR'].size
     nmean = 1.0 + ANNUAL_DRIFT * (taxyear - 2009)
@@ -110,8 +108,6 @@ def constrain_data(xdf):
     xdf: Pandas DataFrame
         contains randomized data to be constrained.
     """
-    # pylint: disable=no-member
-    # (above pylint comment eliminates several bogus np warnings)
     if DEBUG:
         return
     # constraint: e00200 = e00200p + e00200s
@@ -121,7 +117,6 @@ def constrain_data(xdf):
     # constraint: e02100 = e02100p + e02100s
     xdf['e02100'] = xdf['e02100p'] + xdf['e02100s']
     # constraint: e00600 >= e00650
-    # pylint: disable=assignment-from-no-return
     xdf['e00600'] = np.maximum(xdf['e00600'], xdf['e00650'])
     # constraint: e01500 >= e01700
     xdf['e01500'] = np.maximum(xdf['e01500'], xdf['e01700'])
@@ -139,7 +134,6 @@ def main(taxyear, rnseed, ssize):
         sys.stderr.write(msg + '\n')
         return 1
     xdf = pd.read_csv(pufcsv_filename)
-    # pylint: disable=no-member
 
     # remove xdf variables not needed in xYY.csv file
     if TRACE:

--- a/taxcalc/validation/taxsim/prepare_taxcalc_input.py
+++ b/taxcalc/validation/taxsim/prepare_taxcalc_input.py
@@ -84,7 +84,6 @@ def translate(ivar):
     invar['f2441'] = ivar.loc[:, 8]
     invar['n24'] = ivar.loc[:, 9]
     num_eitc_qualified_kids = ivar.loc[:, 10]
-    # pylint: disable=assignment-from-no-return
     invar['EIC'] = np.minimum(num_eitc_qualified_kids, 3)
     num_taxpayers = np.where(mars == 2, 2, 1)
     invar['XTOT'] = num_taxpayers + num_deps


### PR DESCRIPTION
No substantive changes in Tax-Calculator logic or results; just somewhat cleaner code.