### PR TITLE
Add test of calculation of qualified business income deduction (QBID)

### DIFF
--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -827,7 +827,7 @@ def test_qbid_calculation():
       navigating-new-pass-through-provisions-technical-explanation/full
     """
     # In constructing the TPC example filing units, assume that the taxpayer
-    # has business income in the form of e26270==e02000 income and no earnings,
+    # has business income in the form of e26270/e02000 income and no earnings,
     # and that the spouse has no business income and only earnings.
     TPC_YEAR = 2018
     TPC_VARS = (


### PR DESCRIPTION
Add to the `test_calculator.py` file a new test that checks the QBID calculation logic using six example filing units presented in [this TPC publication](https://www.taxpolicycenter.org/publications/navigating-new-pass-through-provisions-technical-explanation/full).  Preliminary test results suggest the need to improve the logic of QBID calculation in Tax-Calculator.  A subsequent pull request will attempt to make some improvements.