### PR TITLE
Add missing check that k1bx14s is zero for all filing units with MARS!=2 

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -169,6 +169,8 @@ class Records(Data):
             raise ValueError(msg.format('e00900s'))
         if not np.allclose(self.e02100s[nospouse], zeros):
             raise ValueError(msg.format('e02100s'))
+        if not np.allclose(self.k1bx14s[nospouse], zeros):
+            raise ValueError(msg.format('k1bx14s'))
         # check that ordinary dividends are no less than qualified dividends
         other_dividends = np.maximum(0., self.e00600 - self.e00650)
         if not np.allclose(self.e00600, self.e00650 + other_dividends,

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -81,6 +81,10 @@ def test_read_cps_data(cps_fullsample):
         u'1,    4,   200000, 100000, 100000\n'
     ),
     (
+        u'RECID,MARS,k1bx14s\n'
+        u'1,    4,   0.03\n'
+    ),
+    (
         u'RxCID,MARS\n'
         u'1,    2\n'
     ),


### PR DESCRIPTION
This pull request adds a missing check on the validity of `k1bx14s` values.  There are no changes in tax logic or tax results.  The added test simply guards against Tax-Calculator misuse when custom data are being specified by the user.