### PR TITLE
Clarify pre_release documentation OUT-OF-DATE error messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ page](https://github.com/).
     ```
     If you do have a copy of the `puf.csv` file used by Tax-Calculator,
     then on the second line above omit the `not requires_pufcsv and`
-    expression so as to execute `py.test -m "not pre_release" -n4`.
+    expression so as to execute `pytest -m "not pre_release" -n4`.
 
     If all the tests pass, you're good to go. If they don't pass, enter
     the following updates at the command line and then try running the
@@ -239,7 +239,7 @@ situations, in which case other contributors are here to help.
    the Tax-Calculator/taxcalc directory::
    ```
    $ pycodestyle .
-   $ py.test -m "not requires_pufcsv and not pre_release" -n4
+   $ pytest -m "not requires_pufcsv and not pre_release" -n4
    ```
    Consult the [testing
    documentation](https://github.com/PSLmodels/Tax-Calculator/blob/master/TESTING.md#tax-calculator-testing-procedures)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ page](https://github.com/).
     the command line in the Tax-Calculator directory:
     ```
     $ cd taxcalc
-    $ py.test -m "not requires_pufcsv and not pre_release" -n4
+    $ pytest -m "not requires_pufcsv and not pre_release" -n4
     ```
     If you do have a copy of the `puf.csv` file used by Tax-Calculator,
     then on the second line above omit the `not requires_pufcsv and`
@@ -139,7 +139,7 @@ page](https://github.com/).
     ```
     
     For more detail on Tax-Calculator testing procedures, read the
-    [testing documentation](https://github.com/PSLmodels/Tax-Calculator/blob/master/TESTING.md).
+    [testing documentation](https://github.com/PSLmodels/Tax-Calculator/blob/master/TESTING.md#tax-calculator-testing-procedures).
     If the tests still don't pass, please contact us.
 
 If you've made it this far, you've successfully made a remote copy (a
@@ -242,7 +242,7 @@ situations, in which case other contributors are here to help.
    $ py.test -m "not requires_pufcsv and not pre_release" -n4
    ```
    Consult the [testing
-   documentation](https://github.com/PSLmodels/Tax-Calculator/blob/master/TESTING.md)
+   documentation](https://github.com/PSLmodels/Tax-Calculator/blob/master/TESTING.md#tax-calculator-testing-procedures)
    for more details.
 
    If the tests do not pass, try to fix the issue by using the

--- a/taxcalc/tests/test_docs.py
+++ b/taxcalc/tests/test_docs.py
@@ -33,6 +33,12 @@ def test_docs_uguide_up_to_date(tests_path):
             target_up_to_date = False
     if not target_up_to_date:
         msg = 'Tax-Calculator/docs/uguide.html IS NOT UP-TO-DATE\n'
+        msg += '###                                               \n'
+        msg += '### If you see this when preparing a pull request,\n'
+        msg += '### you are misusing pytest.  Please read the     \n'
+        msg += '### testing instructions in the Contributor Guide \n'
+        msg += '### and ignore the following intructions.         \n'
+        msg += '###                                               \n'
         msg += 'FIX BY DOING THIS:                              \n'
         msg += ' $ cd Tax-Calculator/docs                       \n'
         msg += ' $ python make_uguide.py                        \n'
@@ -61,6 +67,12 @@ def test_docs_cookbook_up_to_date(tests_path):
             target_up_to_date = False
     if not target_up_to_date:
         msg = 'Tax-Calculator/docs/cookbook.html IS NOT UP-TO-DATE:    \n'
+        msg += '###                                               \n'
+        msg += '### If you see this when preparing a pull request,\n'
+        msg += '### you are misusing pytest.  Please read the     \n'
+        msg += '### testing instructions in the Contributor Guide \n'
+        msg += '### and ignore the following intructions.         \n'
+        msg += '###                                               \n'
         msg += 'EDIT cookbook.html SO THAT IT REFERENCES               \n'
         msg += '- ALL cookbook/recipe*py FILES,                        \n'
         msg += '- ALL cookbook/recipe*res FILES,                       \n'


### PR DESCRIPTION
Try harder to prevent misuse of `pytest` by people developing routine pull requests.
No changes in tax logic or results.