### PR TITLE
Modify how taxcalc handles CPI index toggling

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -847,8 +847,6 @@ class Parameters():
         )
         for year in sorted(revision.keys()):
             for name in revision[year]:
-                if name.endswith('-indexed'):
-                    name = name[:-8]
                 if self._vals[name]['indexed']:
                     if name not in known_years:
                         known_years[name] = kyrs_in_revision

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -847,6 +847,8 @@ class Parameters():
         )
         for year in sorted(revision.keys()):
             for name in revision[year]:
+                if name.endswith('-indexed'):
+                    name = name[:-8]
                 if self._vals[name]['indexed']:
                     if name not in known_years:
                         known_years[name] = kyrs_in_revision

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -967,3 +967,14 @@ def test_reform_with_scalar_vector_errors():
     reform2 = {'ID_Medical_frt': {2020: [0.08]}}
     with pytest.raises(ValueError):
         policy2.implement_reform(reform2)
+
+
+def test_index_offset_reform():
+    """
+    Test a reform that includes both a change in CPI offset and a change in
+    a variable's indexed status.
+    """
+    reform = {'CTC_c-indexed': {2020: True},
+              'CPI_offset': {2020: -0.005}}
+    pol = Policy()
+    pol.implement_reform(reform)


### PR DESCRIPTION
This PR addressed issue #2363. I've slightly modified how taxcalc handles reform parameters ending in `-indexed` to avoid getting an error like the one defined in the linked issue. I also added a test for this type of reform. I'm happy to update this PR if @martinholmer or @MattHJensen decided on a different method of fixing the bug.

cc @hdoupe 