### PR TITLE
Fix for CPI_offset logic

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -831,7 +831,8 @@ class Parameters():
         assert first_cpi_offset_year > 0
         # adjust inflation rates
         cpi_offset = getattr(self, '_CPI_offset')
-        for idx in range(0, self.num_years):
+        first_cpi_offset_ix = first_cpi_offset_year - self.start_year
+        for idx in range(first_cpi_offset_ix, self.num_years):
             infrate = round(self._inflation_rates[idx] + cpi_offset[idx], 6)
             self._inflation_rates[idx] = infrate
         # revert indexed parameter values to policy_current_law.json values

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -1003,3 +1003,30 @@ def test_index_offset_reform():
     expvalue = round(pvalue2[2020] * (1. + expindexrate), 2)
     # ... compare expected value with actual value of pvalue2 for 2021
     assert np.allclose([expvalue], [pvalue2[2021]])
+
+
+def test_cpi_offset_affect_on_prior_years():
+    """
+    Test that CPI_offset does not have affect on inflation
+    rates in earlier years.
+    """
+    reform = {'CPI_offset': {2022: -0.005}}
+    p1 = Policy()
+    p2 = Policy()
+    p2.implement_reform(reform)
+
+    start_year = p1.start_year
+    p1_rates = np.array(p1.inflation_rates())
+    p2_rates = np.array(p2.inflation_rates())
+
+    # Inflation rates prior to 2022 are the same.
+    np.testing.assert_allclose(
+        p1_rates[:2022 - start_year],
+        p2_rates[:2022 - start_year]
+    )
+
+    # Inflation rate in 2022 was updated.
+    np.testing.assert_allclose(
+        p1_rates[2022 - start_year + 1],
+        p2_rates[2022 - start_year + 1] - (-0.005)
+    )

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -1027,6 +1027,6 @@ def test_cpi_offset_affect_on_prior_years():
 
     # Inflation rate in 2022 was updated.
     np.testing.assert_allclose(
-        p1_rates[2022 - start_year + 1],
-        p2_rates[2022 - start_year + 1] - (-0.005)
+        p1_rates[2022 - start_year],
+        p2_rates[2022 - start_year] - (-0.005)
     )


### PR DESCRIPTION
When the `CPI_offset` parameter is updated in 2018 or later, the values from prior years are re-applied to the inflation rates. Here's an example demonstrating the behavior:

```python
import numpy as np

from taxcalc import Policy


p1 = Policy()
p2 = Policy()
p2.implement_reform({"CPI_offset": {2022: -0.005}})

p1_rates = p1.inflation_rates()
p2_rates = p2.inflation_rates()

for year in range(2013, 2030):
    print(
        year,
        p1_rates[year - 2013],
        p2_rates[year - 2013],
        np.round(p1_rates[year - 2013] - p2_rates[year - 2013], 4)
    )

# output:
2013 0.0148 0.0148 0.0
2014 0.0159 0.0159 0.0
2015 0.0012 0.0012 0.0
2016 0.0127 0.0127 0.0
2017 0.0187 0.0162 0.0025 # p1 is 0.0025 greater than p2
2018 0.0224 0.0199 0.0025 # even though they should be equal
2019 0.0186 0.0161 0.0025
2020 0.0233 0.0208 0.0025
2021 0.0229 0.0204 0.0025
2022 0.0228 0.0178 0.005
2023 0.0221 0.0171 0.005
2024 0.0211 0.0161 0.005
2025 0.0209 0.0159 0.005
2026 0.0211 0.0161 0.005
2027 0.0208 0.0158 0.005
2028 0.021 0.016 0.005
2029 0.021 0.016 0.005

```

This PR only applies the offset starting in the first year that `CPI_offset` is modified in the revision. 
