### PR TITLE
Resolve Bokeh deprecation warning

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,7 +11,7 @@ requirements:
     - python
     - "numpy>=1.14"
     - "pandas>=0.23"
-    - "bokeh>=0.13"
+    - "bokeh>=1.4.0"
     - requests
     - numba
 
@@ -19,7 +19,7 @@ requirements:
     - python
     - "numpy>=1.14"
     - "pandas>=0.23"
-    - "bokeh>=0.13"
+    - "bokeh>=1.4.0"
     - requests
     - numba
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ dependencies:
 - python
 - "numpy>=1.14"
 - "pandas>=0.23"
-- "bokeh>=0.13"
+- "bokeh>=1.4.0"
 - requests
 - numba
 - pytest

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1101,9 +1101,9 @@ def xtr_graph_plot(data,
     fig.title.text_font_size = '12pt'
     lines = data['lines']
     fig.line(lines.index, lines.base,
-             line_color='blue', line_width=3, legend='Baseline')
+             line_color='blue', line_width=3, legend_label='Baseline')
     fig.line(lines.index, lines.reform,
-             line_color='red', line_width=3, legend='Reform')
+             line_color='red', line_width=3, legend_label='Reform')
     fig.circle(0, 0, visible=False)  # force zero to be included on y axis
     if xlabel == '':
         xlabel = data['xlabel']


### PR DESCRIPTION
This PR updates Bokeh attribute naming to avoid the deprecation warning reported by @MaxGhenis  in #2389

I've also updated the Bokeh version requirement to 1.4.0 in `environment.yml` and  `conda.recipe/meta.yaml` because the `legend_label` attribute was introduced in Bokeh 1.4.0