### PR TITLE
Specify where agg csv files are in tests

### DIFF
--- a/taxcalc/tests/test_cpscsv.py
+++ b/taxcalc/tests/test_cpscsv.py
@@ -58,6 +58,7 @@ def test_agg(tests_path, cps_fullsample):
         msg += '--- if new OK, copy cpscsv_agg_actual.csv to  ---\n'
         msg += '---                 cpscsv_agg_expect.csv     ---\n'
         msg += '---            and rerun test.                ---\n'
+        msg += '---       (both are in taxcalc/tests)         ---\n'
         msg += '-------------------------------------------------\n'
         raise ValueError(msg)
     # create aggregate diagnostic table using unweighted sub-sample of records

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -64,6 +64,7 @@ def test_agg(tests_path, puf_fullsample):
         msg += '--- if new OK, copy pufcsv_agg_actual.csv to  ---\n'
         msg += '---                 pufcsv_agg_expect.csv     ---\n'
         msg += '---            and rerun test.                ---\n'
+        msg += '---       (both are in taxcalc/tests)         ---\n'
         msg += '-------------------------------------------------\n'
         raise ValueError(msg)
     # create aggregate diagnostic table using unweighted sub-sample of records


### PR DESCRIPTION
This is effectively documentation only. Adds a note in the CPS and PUF agg csv tests stating where the files are, to help the user know where to copy from when the expected aggs change.