### PR TITLE
Expand bounds on growdiff values validation

### DIFF
--- a/taxcalc/growdiff.json
+++ b/taxcalc/growdiff.json
@@ -5,7 +5,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ACGNS": {
@@ -14,7 +14,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ACPIM": {
@@ -23,7 +23,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ACPIU": {
@@ -32,7 +32,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ADIVS": {
@@ -41,7 +41,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "AINTS": {
@@ -50,7 +50,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "AIPD": {
@@ -59,7 +59,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ASCHCI": {
@@ -68,7 +68,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ASCHCL": {
@@ -77,7 +77,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ASCHEI": {
@@ -86,7 +86,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ASCHEL": {
@@ -95,7 +95,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ASCHF": {
@@ -104,7 +104,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ASOCSEC": {
@@ -113,7 +113,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ATXPY": {
@@ -122,7 +122,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "AUCOMP": {
@@ -131,7 +131,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "AWAGE": {
@@ -140,7 +140,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ABENOTHER": {
@@ -149,7 +149,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ABENMCARE": {
@@ -158,7 +158,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
 
@@ -168,7 +168,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
 
@@ -178,7 +178,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
 
@@ -188,7 +188,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
 
@@ -198,7 +198,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
 
@@ -208,7 +208,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
 
@@ -218,7 +218,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     },
 
     "ABENVET": {
@@ -227,7 +227,7 @@
         "value_type": "real",
         "value_yrs": [2013],
         "value": [0.0],
-        "valid_values": {"min": -1, "max": 1}
+        "valid_values": {"min": -10, "max": 10}
     }
 
 }


### PR DESCRIPTION
This PR expands the range of valid values for parameters in `growdiff.json` from `{"min": -1, "max": 1}` to `{"min": -10, "max": 10}`. This will allow users to blow up extrapolated input variables by more than 100%. 