### PR TITLE
Add python 3.8 to travis ci matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   # Install conda


### PR DESCRIPTION
This PR adds Python 3.8 to the travis testing configuration. As more projects move off of Python 3.6 to Python 3.7 and Python 3.8, it may be worth removing Python 3.6 from the build matrix to save CI/CD time.