### PR TITLE
[WIP] Bump Paramtools requirement to 0.14.2 -- OLD

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,4 @@ dependencies:
 - pycodestyle
 - pylint
 - coverage
-- "paramtools>=0.14.0"
+- "paramtools>=0.14.2"

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -37,7 +37,7 @@ def test_for_consistency(tests_path):
         'pycodestyle',
         'pylint',
         'coverage',
-        "paramtools>=0.14.0"
+        "paramtools>=0.14.2"
     ])
     # read conda.recipe/meta.yaml requirements
     meta_file = os.path.join(tests_path, '..', '..',


### PR DESCRIPTION
Paramtools 0.14.2 resolves error thrown by `make_uguide.py`.

cc @MattHJensen @hdoupe @MaxGhenis