### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   build-and-deploy:
+    if: github.repository == ‘PSLmodels/Tax-Calculator’
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -25,8 +25,8 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install jupyter-book
-          pip install -e .
           conda install -c pslmodels behresp
+          pip install -e .
           cd docs
           jb build .
 


### PR DESCRIPTION
This PR makes two changes to the GH action file to build and deploy the JB docs:
1) Changes order in which `behresp` and `taxcalc` packages are installed to make sure current TC version used.
2) Adds a conditional statement so build and deploy only run on master branch of the PSLmodels/Tax-Calculator repo.