### PR TITLE
TAXSIM27 validation updates [Review]

### DIFF
--- a/taxcalc/validation/taxsim27/README.md
+++ b/taxcalc/validation/taxsim27/README.md
@@ -36,6 +36,17 @@ In the following results, when we say "same results" we mean that the
 federal individual income tax liabilities and payroll tax liabilities
 being compared have differences of no larger than one cent.
 
+
+Instructions
+------------------
+
+1. Use `taxsim_input.py` to create the `.in` files necessary to input into TAXSIM.
+2. Head to the [TAXSIM website](http://users.nber.org/~taxsim/taxsim27/) and under _Upload a file_, place each of the `.in` files in and save the outputs as `LYY.in.out-taxsim`. When you run the TAXSIM simulation, make sure to switch _Show detailed intermediate calculations_ to the **on** setting.
+3. Open each of these `.in.out-taxsim` filed and remove the first few lines containing the variable names.
+4. Compress these files in a `.zip` format (make sure to compress the files themselves and **do not** place the files in a folder and compress the folder).
+5. Go to the `validation` directory above the directory this `README` is housed in and run the shell script `tests.sh`.
+
+
 Validation Results
 ------------------
 

--- a/taxcalc/validation/taxsim27/README.md
+++ b/taxcalc/validation/taxsim27/README.md
@@ -41,7 +41,7 @@ Instructions
 ------------------
 
 1. Use `taxsim_input.py` to create the `.in` files necessary to input into TAXSIM.
-2. Head to the [TAXSIM website](http://users.nber.org/~taxsim/taxsim27/) and under _Upload a file_, place each of the `.in` files in and save the outputs as `LYY.in.out-taxsim`. When you run the TAXSIM simulation, make sure to switch _Show detailed intermediate calculations_ to the **on** setting.
+2. Head to the [TAXSIM website](http://users.nber.org/~taxsim/taxsim27/) and under _Upload a file_, place each of the `.in` files in and save the outputs as `LYY.in.out-taxsim`. When you run the TAXSIM simulation, make sure to switch _Show detailed intermediate calculations_ to _on_.
 3. Open each of these `.in.out-taxsim` filed and remove the first few lines containing the variable names.
 4. Compress these files in a `.zip` format (make sure to compress the files themselves and **do not** place the files in a folder and compress the folder).
 5. Go to the `validation` directory above the directory this `README` is housed in and run the shell script `tests.sh`.

--- a/taxcalc/validation/taxsim27/README.md
+++ b/taxcalc/validation/taxsim27/README.md
@@ -40,11 +40,11 @@ being compared have differences of no larger than one cent.
 Instructions
 ------------------
 
-1. Use `taxsim_input.py` to create the `.in` files necessary to input into TAXSIM.
-2. Head to the [TAXSIM website](http://users.nber.org/~taxsim/taxsim27/) and under _Upload a file_, place each of the `.in` files in and save the outputs as `LYY.in.out-taxsim`. When you run the TAXSIM simulation, make sure to switch _Show detailed intermediate calculations_ to _on_.
-3. Open each of these `.in.out-taxsim` filed and remove the first few lines containing the variable names.
+1. Use `taxsim_input.py` to create the `.in` files necessary to input into TAXSIM-27.
+2. Head to the [TAXSIM-27 website](http://users.nber.org/~taxsim/taxsim27/) and under _Upload a file_, place each of the `.in` files in and save the outputs as `LYY.in.out-taxsim`. When you run the TAXSIM-27 simulation, make sure to switch _Show detailed intermediate calculations_ to _on_.
+3. Open each of these `.in.out-taxsim` files and remove the first few lines containing the variable names.
 4. Compress these files in a `.zip` format (make sure to compress the files themselves and **do not** place the files in a folder and compress the folder).
-5. Go to the `validation` directory above the directory this `README` is housed in and run the shell script `tests.sh`.
+5. Navigate to `taxcalc/validation` and run `tests.sh`.
 
 
 Validation Results

--- a/taxcalc/validation/taxsim27/taxsim_input.py
+++ b/taxcalc/validation/taxsim27/taxsim_input.py
@@ -159,81 +159,107 @@ def sample_dataframe(assump, year, offset):
     mstat = np.where(urn < assump['joint_frac'], 2, 1)
     sdict[4] = mstat
     # (05) PAGE
-    sdict[5] = np.random.random_integers(assump['min_age'],
+    sdict[5] = np.random.randint(assump['min_age'],
                                          assump['max_age'],
                                          size)
     # (06) SAGE
-    age_diff = np.random.random_integers(assump['min_age_diff'],
+    age_diff = np.random.randint(assump['min_age_diff'],
                                          assump['max_age_diff'],
                                          size)
     sage = sdict[5] + age_diff
     sdict[6] = np.where(mstat == 2, np.maximum(sage, assump['min_age']), zero)
     # (07-10) DEPX, DEP13, DEP17, DEP18
-    depx = np.random.random_integers(0, assump['max_depx'], size)
-    d18 = np.random.random_integers(0, assump['max_dep18'], size)
+    depx = np.random.randint(0, assump['max_depx'], size)
+    d18 = np.random.randint(0, assump['max_dep18'], size)
     dep18 = np.where(d18 <= depx, d18, depx)
-    d17 = np.random.random_integers(0, assump['max_dep17'], size)
+    d17 = np.random.randint(0, assump['max_dep17'], size)
     dep17 = np.where(d17 <= dep18, d17, dep18)
-    d13 = np.random.random_integers(0, assump['max_dep13'], size)
+    d13 = np.random.randint(0, assump['max_dep13'], size)
     dep13 = np.where(d13 <= dep17, d13, dep17)
     sdict[7] = depx
     sdict[8] = dep13
     sdict[9] = dep17
     sdict[10] = dep18
     # (11) PWAGES
-    pwages_yng = np.random.random_integers(0, assump['max_pwages_yng'], size)
-    pwages_old = np.random.random_integers(0, assump['max_pwages_old'], size)
+    pwages_yng = np.random.randint(0, assump['max_pwages_yng'], size)
+    pwages_old = np.random.randint(0, assump['max_pwages_old'], size)
     sdict[11] = np.where(sdict[5] >= 65, pwages_old, pwages_yng) * 1000
     # (12) SWAGES
-    swages_yng = np.random.random_integers(0, assump['max_swages_yng'], size)
-    swages_old = np.random.random_integers(0, assump['max_swages_old'], size)
+    swages_yng = np.random.randint(0, assump['max_swages_yng'], size)
+    swages_old = np.random.randint(0, assump['max_swages_old'], size)
     swages = np.where(sdict[6] >= 65, swages_old, swages_yng) * 1000
     sdict[12] = np.where(mstat == 2, swages, zero)
     # (13) DIVIDENDS
-    sdict[13] = np.random.random_integers(0, assump['max_divinc'], size) * 1000
+    if assump['max_divinc'] == 0:
+        sdict[13] = zero
+    else:
+        sdict[13] = np.random.randint(0, assump['max_divinc'], size) * 1000
     # (14) INTREC
-    sdict[14] = np.random.random_integers(0, assump['max_intinc'], size) * 1000
+    if assump['max_intinc'] == 0:
+        sdict[14] = zero
+    else:
+        sdict[14] = np.random.randint(0, assump['max_intinc'], size) * 1000
     # (15) STCG
-    sdict[15] = np.random.random_integers(assump['min_stcg'],
-                                          assump['max_stcg'],
-                                          size) * 1000
+    if assump['min_stcg'] & assump['max_stcg'] == 0:
+        sdict[15] = zero
+    else:
+        sdict[15] = np.random.randint(assump['min_stcg'], assump['max_stcg'], size) * 1000
     # (16) LTCG
-    sdict[16] = np.random.random_integers(assump['min_ltcg'],
-                                          assump['max_ltcg'],
-                                          size) * 1000
+    if assump['min_ltcg'] & assump['min_ltcg'] == 0:
+        sdict[16] = zero
+    else:
+        sdict[16] = np.random.randint(assump['min_ltcg'], assump['max_ltcg'], size) * 1000
     # (17) OTHERPROP
-    sdict[17] = np.random.random_integers(0,
-                                          assump['max_other_prop_inc'],
-                                          size) * 1000
+    if assump['max_other_prop_inc'] == 0:
+        sdict[17] = zero
+    else:
+        sdict[17] = np.random.randint(0, assump['max_other_prop_inc'], size) * 1000
     # (18) NONPROP
-    sdict[18] = np.random.random_integers(0,
-                                          assump['max_other_nonprop_inc'],
-                                          size) * 1000
+    if assump['max_other_nonprop_inc'] == 0:
+        sdict[18] = zero
+    else:
+        sdict[18] = np.random.randint(0, assump['max_other_nonprop_inc'], size) * 1000
     # (19) PENSIONS
-    sdict[19] = np.random.random_integers(0, assump['max_pnben'], size) * 1000
+    if assump['max_pnben'] == 0:
+        sdict[19] = zero
+    else:
+        sdict[19] = np.random.randint(0, assump['max_pnben'], size) * 1000
     # (20) GSSI
-    sdict[20] = np.random.random_integers(0, assump['max_ssben'], size) * 1000
+    if assump['max_ssben'] == 0:
+        sdict[20] = zero
+    else:
+        sdict[20] = np.random.randint(0, assump['max_ssben'], size) * 1000
     # (21) UI
-    sdict[21] = np.random.random_integers(0, assump['max_uiben'], size) * 1000
+    if assump['max_uiben'] == 0:
+        sdict[21] = zero
+    else:
+        sdict[21] = np.random.randint(0, assump['max_uiben'], size) * 1000
     # (22) TRANSFERS (non-taxable in federal income tax)
     sdict[22] = zero
     # (23) RENTPAID (used only in some state income tax laws)
     sdict[23] = zero
     # (24) PROPTAX
-    sdict[24] = np.random.random_integers(0,
-                                          assump['max_ided_proptax'],
-                                          size) * 1000
+    if assump['max_ided_proptax'] == 0:
+        sdict[24] = zero
+    else:
+        sdict[24] = np.random.randint(0, assump['max_ided_proptax'], size) * 1000
     # (25) OTHERITEM
-    sdict[25] = np.random.random_integers(0,
-                                          assump['max_ided_nopref'],
-                                          size) * 1000
+    if assump['max_ided_nopref'] == 0:
+        sdict[25] = zero
+    else:    
+        sdict[25] = np.random.randint(0, assump['max_ided_nopref'], size) * 1000
     # (26) CHILDCARE (TAXSIM-27 EXPECTS ZERO IF NO QUALIFYING CHILDRED)
-    ccexp = np.random.random_integers(0, assump['max_ccexp'], size) * 1000
+    if assump['max_ccexp'] == 0:
+        ccexp = zero
+    else:
+        ccexp = np.random.randint(0, assump['max_ccexp'], size) * 1000
     sdict[26] = np.where(dep13 > 0, ccexp, zero)
     # (27) MORTGAGE
-    sdict[27] = np.random.random_integers(0,
-                                          assump['max_ided_mortgage'],
-                                          size) * 1000
+    if assump['max_ided_mortgage'] == 0:
+        sdict[27] = zero
+    else:
+        sdict[27] = np.random.randint(0, assump['max_ided_mortgage'], size) * 1000
+        
     smpl = pd.DataFrame(sdict)
     return smpl
 

--- a/taxcalc/validation/taxsim27/taxsim_input.py
+++ b/taxcalc/validation/taxsim27/taxsim_input.py
@@ -160,106 +160,80 @@ def sample_dataframe(assump, year, offset):
     sdict[4] = mstat
     # (05) PAGE
     sdict[5] = np.random.randint(assump['min_age'],
-                                         assump['max_age'],
+                                         assump['max_age']+1,
                                          size)
     # (06) SAGE
     age_diff = np.random.randint(assump['min_age_diff'],
-                                         assump['max_age_diff'],
+                                         assump['max_age_diff']+1,
                                          size)
     sage = sdict[5] + age_diff
     sdict[6] = np.where(mstat == 2, np.maximum(sage, assump['min_age']), zero)
     # (07-10) DEPX, DEP13, DEP17, DEP18
-    depx = np.random.randint(0, assump['max_depx'], size)
-    d18 = np.random.randint(0, assump['max_dep18'], size)
+    depx = np.random.randint(0, assump['max_depx']+1, size)
+    d18 = np.random.randint(0, assump['max_dep18']+1, size)
     dep18 = np.where(d18 <= depx, d18, depx)
-    d17 = np.random.randint(0, assump['max_dep17'], size)
+    d17 = np.random.randint(0, assump['max_dep17']+1, size)
     dep17 = np.where(d17 <= dep18, d17, dep18)
-    d13 = np.random.randint(0, assump['max_dep13'], size)
+    d13 = np.random.randint(0, assump['max_dep13']+1, size)
     dep13 = np.where(d13 <= dep17, d13, dep17)
     sdict[7] = depx
     sdict[8] = dep13
     sdict[9] = dep17
     sdict[10] = dep18
     # (11) PWAGES
-    pwages_yng = np.random.randint(0, assump['max_pwages_yng'], size)
-    pwages_old = np.random.randint(0, assump['max_pwages_old'], size)
+    pwages_yng = np.random.randint(0, assump['max_pwages_yng']+1, size)
+    pwages_old = np.random.randint(0, assump['max_pwages_old']+1, size)
     sdict[11] = np.where(sdict[5] >= 65, pwages_old, pwages_yng) * 1000
     # (12) SWAGES
-    swages_yng = np.random.randint(0, assump['max_swages_yng'], size)
-    swages_old = np.random.randint(0, assump['max_swages_old'], size)
+    swages_yng = np.random.randint(0, assump['max_swages_yng']+1, size)
+    swages_old = np.random.randint(0, assump['max_swages_old']+1, size)
     swages = np.where(sdict[6] >= 65, swages_old, swages_yng) * 1000
     sdict[12] = np.where(mstat == 2, swages, zero)
     # (13) DIVIDENDS
-    if assump['max_divinc'] == 0:
-        sdict[13] = zero
-    else:
-        sdict[13] = np.random.randint(0, assump['max_divinc'], size) * 1000
+    sdict[13] = np.random.randint(0, assump['max_divinc']+1, size) * 1000
     # (14) INTREC
-    if assump['max_intinc'] == 0:
-        sdict[14] = zero
-    else:
-        sdict[14] = np.random.randint(0, assump['max_intinc'], size) * 1000
+    sdict[14] = np.random.randint(0, assump['max_intinc']+1, size) * 1000
     # (15) STCG
-    if assump['min_stcg'] & assump['max_stcg'] == 0:
-        sdict[15] = zero
-    else:
-        sdict[15] = np.random.randint(assump['min_stcg'], assump['max_stcg'], size) * 1000
+    sdict[15] = np.random.randint(assump['min_stcg'],
+                                          assump['max_stcg']+1,
+                                          size) * 1000
     # (16) LTCG
-    if assump['min_ltcg'] & assump['min_ltcg'] == 0:
-        sdict[16] = zero
-    else:
-        sdict[16] = np.random.randint(assump['min_ltcg'], assump['max_ltcg'], size) * 1000
+    sdict[16] = np.random.randint(assump['min_ltcg'],
+                                          assump['max_ltcg']+1,
+                                          size) * 1000
     # (17) OTHERPROP
-    if assump['max_other_prop_inc'] == 0:
-        sdict[17] = zero
-    else:
-        sdict[17] = np.random.randint(0, assump['max_other_prop_inc'], size) * 1000
+    sdict[17] = np.random.randint(0,
+                                          assump['max_other_prop_inc']+1,
+                                          size) * 1000
     # (18) NONPROP
-    if assump['max_other_nonprop_inc'] == 0:
-        sdict[18] = zero
-    else:
-        sdict[18] = np.random.randint(0, assump['max_other_nonprop_inc'], size) * 1000
+    sdict[18] = np.random.randint(0,
+                                          assump['max_other_nonprop_inc']+1,
+                                          size) * 1000
     # (19) PENSIONS
-    if assump['max_pnben'] == 0:
-        sdict[19] = zero
-    else:
-        sdict[19] = np.random.randint(0, assump['max_pnben'], size) * 1000
+    sdict[19] = np.random.randint(0, assump['max_pnben']+1, size) * 1000
     # (20) GSSI
-    if assump['max_ssben'] == 0:
-        sdict[20] = zero
-    else:
-        sdict[20] = np.random.randint(0, assump['max_ssben'], size) * 1000
+    sdict[20] = np.random.randint(0, assump['max_ssben']+1, size) * 1000
     # (21) UI
-    if assump['max_uiben'] == 0:
-        sdict[21] = zero
-    else:
-        sdict[21] = np.random.randint(0, assump['max_uiben'], size) * 1000
+    sdict[21] = np.random.randint(0, assump['max_uiben']+1, size) * 1000
     # (22) TRANSFERS (non-taxable in federal income tax)
     sdict[22] = zero
     # (23) RENTPAID (used only in some state income tax laws)
     sdict[23] = zero
     # (24) PROPTAX
-    if assump['max_ided_proptax'] == 0:
-        sdict[24] = zero
-    else:
-        sdict[24] = np.random.randint(0, assump['max_ided_proptax'], size) * 1000
+    sdict[24] = np.random.randint(0,
+                                          assump['max_ided_proptax']+1,
+                                          size) * 1000
     # (25) OTHERITEM
-    if assump['max_ided_nopref'] == 0:
-        sdict[25] = zero
-    else:    
-        sdict[25] = np.random.randint(0, assump['max_ided_nopref'], size) * 1000
+    sdict[25] = np.random.randint(0,
+                                          assump['max_ided_nopref']+1,
+                                          size) * 1000
     # (26) CHILDCARE (TAXSIM-27 EXPECTS ZERO IF NO QUALIFYING CHILDRED)
-    if assump['max_ccexp'] == 0:
-        ccexp = zero
-    else:
-        ccexp = np.random.randint(0, assump['max_ccexp'], size) * 1000
+    ccexp = np.random.randint(0, assump['max_ccexp']+1, size) * 1000
     sdict[26] = np.where(dep13 > 0, ccexp, zero)
     # (27) MORTGAGE
-    if assump['max_ided_mortgage'] == 0:
-        sdict[27] = zero
-    else:
-        sdict[27] = np.random.randint(0, assump['max_ided_mortgage'], size) * 1000
-        
+    sdict[27] = np.random.randint(0,
+                                          assump['max_ided_mortgage']+1,
+                                          size) * 1000
     smpl = pd.DataFrame(sdict)
     return smpl
 

--- a/taxcalc/validation/taxsim27/taxsim_input.py
+++ b/taxcalc/validation/taxsim27/taxsim_input.py
@@ -160,12 +160,12 @@ def sample_dataframe(assump, year, offset):
     sdict[4] = mstat
     # (05) PAGE
     sdict[5] = np.random.randint(assump['min_age'],
-                                         assump['max_age']+1,
-                                         size)
+                                 assump['max_age']+1,
+                                 size)
     # (06) SAGE
     age_diff = np.random.randint(assump['min_age_diff'],
-                                         assump['max_age_diff']+1,
-                                         size)
+                                 assump['max_age_diff']+1,
+                                 size)
     sage = sdict[5] + age_diff
     sdict[6] = np.where(mstat == 2, np.maximum(sage, assump['min_age']), zero)
     # (07-10) DEPX, DEP13, DEP17, DEP18
@@ -195,20 +195,20 @@ def sample_dataframe(assump, year, offset):
     sdict[14] = np.random.randint(0, assump['max_intinc']+1, size) * 1000
     # (15) STCG
     sdict[15] = np.random.randint(assump['min_stcg'],
-                                          assump['max_stcg']+1,
-                                          size) * 1000
+                                  assump['max_stcg']+1,
+                                  size) * 1000
     # (16) LTCG
     sdict[16] = np.random.randint(assump['min_ltcg'],
-                                          assump['max_ltcg']+1,
-                                          size) * 1000
+                                  assump['max_ltcg']+1,
+                                  size) * 1000
     # (17) OTHERPROP
     sdict[17] = np.random.randint(0,
-                                          assump['max_other_prop_inc']+1,
-                                          size) * 1000
+                                  assump['max_other_prop_inc']+1,
+                                  size) * 1000
     # (18) NONPROP
     sdict[18] = np.random.randint(0,
-                                          assump['max_other_nonprop_inc']+1,
-                                          size) * 1000
+                                  assump['max_other_nonprop_inc']+1,
+                                  size) * 1000
     # (19) PENSIONS
     sdict[19] = np.random.randint(0, assump['max_pnben']+1, size) * 1000
     # (20) GSSI
@@ -221,19 +221,19 @@ def sample_dataframe(assump, year, offset):
     sdict[23] = zero
     # (24) PROPTAX
     sdict[24] = np.random.randint(0,
-                                          assump['max_ided_proptax']+1,
-                                          size) * 1000
+                                  assump['max_ided_proptax']+1,
+                                  size) * 1000
     # (25) OTHERITEM
     sdict[25] = np.random.randint(0,
-                                          assump['max_ided_nopref']+1,
-                                          size) * 1000
+                                  assump['max_ided_nopref']+1,
+                                  size) * 1000
     # (26) CHILDCARE (TAXSIM-27 EXPECTS ZERO IF NO QUALIFYING CHILDRED)
     ccexp = np.random.randint(0, assump['max_ccexp']+1, size) * 1000
     sdict[26] = np.where(dep13 > 0, ccexp, zero)
     # (27) MORTGAGE
     sdict[27] = np.random.randint(0,
-                                          assump['max_ided_mortgage']+1,
-                                          size) * 1000
+                                  assump['max_ided_mortgage']+1,
+                                  size) * 1000
     smpl = pd.DataFrame(sdict)
     return smpl
 


### PR DESCRIPTION
This PR updates the `README.md` to provide step-by-step instructions for comparing Tax Calculator and TAXSIM27, and also updates the `taxsim_input.py` file.

In `taxsim_input.py`, the `random_integers` `numpy` function is deprecated, so it was changed to `randint`. `taxsim_input.py` was edited to avoid errors thrown when `randint` attempts to generate an integer between 0 and 0.

@Peter-Metz 