### PR TITLE
Update test_for_consitency to handle pip dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,6 @@ dependencies:
 - pylint
 - coverage
 - "paramtools>=0.14.0"
+- pip
+- pip:
+    - jupyter-book

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -37,7 +37,9 @@ def test_for_consistency(tests_path):
         'pycodestyle',
         'pylint',
         'coverage',
-        "paramtools>=0.14.0"
+        "paramtools>=0.14.0",
+        "pip",
+        "jupyter-book",
     ])
     # read conda.recipe/meta.yaml requirements
     meta_file = os.path.join(tests_path, '..', '..',
@@ -53,7 +55,15 @@ def test_for_consistency(tests_path):
                              'environment.yml')
     with open(envr_file, 'r') as stream:
         envr = yaml.safe_load(stream)
-    env = set(envr['dependencies'])
+
+    env = []
+    for dep in envr["dependencies"]:
+        if isinstance(dep, dict):
+            assert list(dep.keys()) == ["pip"]
+            env += dep["pip"]
+        else:
+            env.append(dep)
+    env = set(env)
     # confirm that extras in env (relative to run) equal the dev_pkgs set
     extras = env - run
     assert extras == dev_pkgs


### PR DESCRIPTION
Resolves https://github.com/PSLmodels/Tax-Calculator/pull/2439#issuecomment-663702511. 

This also adds `jupyter-book` as a dependency to demonstrate that the test passes with `pip` dependencies. I'm happy to remove that and let @MaxGhenis add it in #2439.
