### PR TITLE
Work through issues with deprecations in package dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ install:
   - source activate taxcalc-dev
   - conda env update -f environment.yml
   - pip install pyyaml
-  - pip install pytest-pep8
+  - pip install pytest-pycodestyle
   - pip install coverage
   - pip install codecov
   - python setup.py install
 
 # command to run tests
 script:
-  - python -c "import taxcalc"; coverage run -m pytest -v -m "not requires_pufcsv and not pre_release and not local" --pep8
+  - python -c "import taxcalc"; coverage run -m pytest -v -m "not requires_pufcsv and not pre_release and not local" --pycodestyle
 
 after_success:
   - codecov

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,7 +10,7 @@ requirements:
   build:
     - python
     - "numpy>=1.14"
-    - "pandas>=0.23"
+    - "pandas>=1.1.0"
     - "bokeh>=1.4.0"
     - requests
     - numba
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - "numpy>=1.14"
-    - "pandas>=0.23"
+    - "pandas>=1.1.0"
     - "bokeh>=1.4.0"
     - requests
     - numba

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - python
 - "numpy>=1.14"
-- "pandas>=0.23"
+- "pandas>=1.1.0"
 - "bokeh>=1.4.0"
 - requests
 - numba

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -562,12 +562,12 @@ class TaxCalcIO():
                                               pop_quantiles=False,
                                               weight_by_income_measure=False)
         gdfx = dfx.groupby('table_row', as_index=False)
-        rtns_series = gdfx.apply(unweighted_sum, 's006')
-        xinc_series = gdfx.apply(weighted_sum, 'expanded_income')
-        itax_series = gdfx.apply(weighted_sum, 'iitax')
-        ptax_series = gdfx.apply(weighted_sum, 'payrolltax')
-        htax_series = gdfx.apply(weighted_sum, 'lumpsum_tax')
-        ctax_series = gdfx.apply(weighted_sum, 'combined')
+        rtns_series = gdfx.apply(unweighted_sum, 's006').values[:, 1]
+        xinc_series = gdfx.apply(weighted_sum, 'expanded_income').values[:, 1]
+        itax_series = gdfx.apply(weighted_sum, 'iitax').values[:, 1]
+        ptax_series = gdfx.apply(weighted_sum, 'payrolltax').values[:, 1]
+        htax_series = gdfx.apply(weighted_sum, 'lumpsum_tax').values[:, 1]
+        ctax_series = gdfx.apply(weighted_sum, 'combined').values[:, 1]
         # write decile table to text file
         row = 'Weighted Tax {} by Baseline Expanded-Income Decile\n'
         tfile.write(row.format(tkind))

--- a/taxcalc/tests/test_decorators.py
+++ b/taxcalc/tests/test_decorators.py
@@ -7,7 +7,7 @@ import pytest
 import importlib
 import numpy as np
 from pandas import DataFrame
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import taxcalc
 from taxcalc.decorators import *
 

--- a/taxcalc/tests/test_responses.py
+++ b/taxcalc/tests/test_responses.py
@@ -31,12 +31,11 @@ def test_response_json(tests_path):
             con_change = Consumption.read_json_update(jpf_text)
             consumption.update_consumption(con_change)
             del consumption
-            for topkey in['growdiff_baseline', 'growdiff_response']:
+            for topkey in ['growdiff_baseline', 'growdiff_response']:
                 growdiff = GrowDiff()
                 gdiff_change = GrowDiff.read_json_update(jpf_text, topkey)
                 growdiff.update_growdiff(gdiff_change)
                 del growdiff
         else:  # jpf_text is not a valid JSON response assumption file
-            print('test-failing-filename: ' +
-                  jpf)
+            print('test-failing-filename: ' + jpf)
             assert False

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -473,7 +473,7 @@ def test_weighted_mean():
     diffs = grouped.apply(weighted_mean, 'tax_diff')
     exp = pd.Series(data=[16.0 / 12.0, 26.0 / 10.0], index=['a', 'b'])
     exp.index.name = 'label'
-    pd.util.testing.assert_series_equal(exp, diffs)
+    pd.testing.assert_series_equal(exp, diffs)
 
 
 def test_wage_weighted():
@@ -501,7 +501,7 @@ def test_weighted_sum():
     diffs = grouped.apply(weighted_sum, 'tax_diff')
     exp = pd.Series(data=[16.0, 26.0], index=['a', 'b'])
     exp.index.name = 'label'
-    pd.util.testing.assert_series_equal(exp, diffs)
+    pd.testing.assert_series_equal(exp, diffs)
 
 
 EPSILON = 1e-5

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -103,7 +103,7 @@ def test_create_tables(cps_subsample):
                 -0.1,
                 -0.1,
                 -0.6]
-    if not np.allclose(diff[tabcol].values, expected,
+    if not np.allclose(diff[tabcol].values.astype('float'), expected,
                        atol=0.1, rtol=0.0, equal_nan=True):
         test_failure = True
         print('diff xbin', tabcol)
@@ -131,7 +131,7 @@ def test_create_tables(cps_subsample):
                 6.2,
                 3.5,
                 0.6]
-    if not np.allclose(diff[tabcol].values, expected,
+    if not np.allclose(diff[tabcol].values.astype('float'), expected,
                        atol=0.1, rtol=0.0):
         test_failure = True
         print('diff xdec', tabcol)
@@ -155,7 +155,7 @@ def test_create_tables(cps_subsample):
                 11.7,
                 6.6,
                 1.1]
-    if not np.allclose(diff[tabcol].values, expected,
+    if not np.allclose(diff[tabcol].values.astype('float'), expected,
                        atol=0.1, rtol=0.0):
         test_failure = True
         print('diff xdec', tabcol)
@@ -179,7 +179,7 @@ def test_create_tables(cps_subsample):
                 -0.6,
                 -0.3,
                 -0.1]
-    if not np.allclose(diff[tabcol].values, expected,
+    if not np.allclose(diff[tabcol].values.astype('float'), expected,
                        atol=0.1, rtol=0.0, equal_nan=True):
         test_failure = True
         print('diff xdec', tabcol)
@@ -207,7 +207,7 @@ def test_create_tables(cps_subsample):
                 152.4,
                 234.7,
                 347.1]
-    if not np.allclose(dist[tabcol].values, expected,
+    if not np.allclose(dist[tabcol].values.astype('float'), expected,
                        atol=0.1, rtol=0.0):
         test_failure = True
         print('dist xdec', tabcol)
@@ -303,7 +303,7 @@ def test_create_tables(cps_subsample):
                 99.5,
                 194.9,
                 1056.9]
-    if not np.allclose(dist[tabcol], expected,
+    if not np.allclose(dist[tabcol].values.astype('float'), expected,
                        atol=0.1, rtol=0.0):
         test_failure = True
         print('dist xbin', tabcol)
@@ -546,14 +546,17 @@ def test_dist_table_sum_row(cps_subsample):
     tb3, _ = calc.distribution_tables(None, 'weighted_deciles')
     tb4, _ = calc.distribution_tables(None, 'weighted_deciles',
                                       pop_quantiles=True)
-    assert np.allclose(tb1.loc['ALL'], tb2.loc['ALL'])
-    assert np.allclose(tb1.loc['ALL'], tb3.loc['ALL'])
+    assert np.allclose(tb1.loc['ALL'].values.astype('float'),
+                       tb2.loc['ALL'].values.astype('float'))
+    assert np.allclose(tb1.loc['ALL'].values.astype('float'),
+                       tb3.loc['ALL'].values.astype('float'))
     # make sure population count is larger than filing-unit count
     assert tb4.at['ALL', 'count'] > tb1.at['ALL', 'count']
     # make sure population table has same ALL row values as filing-unit table
     for col in ['count', 'count_StandardDed', 'count_ItemDed', 'count_AMT']:
         tb4.at['ALL', col] = tb1.at['ALL', col]
-    assert np.allclose(tb1.loc['ALL'], tb4.loc['ALL'])
+    assert np.allclose(tb1.loc['ALL'].values.astype('float'),
+                       tb4.loc['ALL'].values.astype('float'))
     # make sure population table has same ALL tax liabilities as diagnostic tbl
     dgt = calc.diagnostic_table(1)
     assert np.allclose([tb4.at['ALL', 'iitax'],
@@ -576,14 +579,17 @@ def test_diff_table_sum_row(cps_subsample):
     # create three difference tables and compare their content
     dv1 = calc1.dataframe(DIFF_VARIABLES)
     dv2 = calc2.dataframe(DIFF_VARIABLES)
-    dt1 = create_difference_table(dv1, dv2, 'standard_income_bins', 'iitax')
+    dt1 = create_difference_table(
+        dv1, dv2, 'standard_income_bins', 'iitax')
     dt2 = create_difference_table(dv1, dv2, 'soi_agi_bins', 'iitax')
-    dt3 = create_difference_table(dv1, dv2, 'weighted_deciles', 'iitax',
-                                  pop_quantiles=False)
-    dt4 = create_difference_table(dv1, dv2, 'weighted_deciles', 'iitax',
-                                  pop_quantiles=True)
-    assert np.allclose(dt1.loc['ALL'], dt2.loc['ALL'])
-    assert np.allclose(dt1.loc['ALL'], dt3.loc['ALL'])
+    dt3 = create_difference_table(
+        dv1, dv2, 'weighted_deciles', 'iitax', pop_quantiles=False)
+    dt4 = create_difference_table(
+        dv1, dv2, 'weighted_deciles', 'iitax', pop_quantiles=True)
+    assert np.allclose(dt1.loc['ALL'].values.astype('float'),
+                       dt2.loc['ALL'].values.astype('float'))
+    assert np.allclose(dt1.loc['ALL'].values.astype('float'),
+                       dt3.loc['ALL'].values.astype('float'))
     # make sure population count is larger than filing-unit count
     assert dt4.at['ALL', 'count'] > dt1.at['ALL', 'count']
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -334,9 +334,9 @@ def create_distribution_table(vdf, groupby, income_measure,
         sdf = pd.DataFrame()
         for col in DIST_TABLE_COLUMNS:
             if col in unweighted_columns:
-                sdf[col] = gdf.apply(unweighted_sum, col)
+                sdf[col] = gdf.apply(unweighted_sum, col).values[:, 1]
             else:
-                sdf[col] = gdf.apply(weighted_sum, col)
+                sdf[col] = gdf.apply(weighted_sum, col).values[:, 1]
         return sdf
     # main logic of create_distribution_table
     assert isinstance(vdf, pd.DataFrame)
@@ -477,17 +477,17 @@ def create_difference_table(vdf1, vdf2, groupby, tax_to_diff,
             return dframe[dframe[col_name] > tolerance]['count'].sum()
         # start of additive_stats_dataframe code
         sdf = pd.DataFrame()
-        sdf['count'] = gdf.apply(unweighted_sum, 'count')
-        sdf['tax_cut'] = gdf.apply(count_lt_zero, 'tax_diff')
-        sdf['tax_inc'] = gdf.apply(count_gt_zero, 'tax_diff')
-        sdf['tot_change'] = gdf.apply(weighted_sum, 'tax_diff')
-        sdf['ubi'] = gdf.apply(weighted_sum, 'ubi')
+        sdf['count'] = gdf.apply(unweighted_sum, 'count').values[:, 1]
+        sdf['tax_cut'] = gdf.apply(count_lt_zero, 'tax_diff').values[:, 1]
+        sdf['tax_inc'] = gdf.apply(count_gt_zero, 'tax_diff').values[:, 1]
+        sdf['tot_change'] = gdf.apply(weighted_sum, 'tax_diff').values[:, 1]
+        sdf['ubi'] = gdf.apply(weighted_sum, 'ubi').values[:, 1]
         sdf['benefit_cost_total'] = gdf.apply(weighted_sum,
-                                              'benefit_cost_total')
+                                              'benefit_cost_total').values[:, 1]
         sdf['benefit_value_total'] = gdf.apply(weighted_sum,
-                                               'benefit_value_total')
-        sdf['atinc1'] = gdf.apply(weighted_sum, 'atinc1')
-        sdf['atinc2'] = gdf.apply(weighted_sum, 'atinc2')
+                                               'benefit_value_total').values[:, 1]
+        sdf['atinc1'] = gdf.apply(weighted_sum, 'atinc1').values[:, 1]
+        sdf['atinc2'] = gdf.apply(weighted_sum, 'atinc2').values[:, 1]
         return sdf
     # main logic of create_difference_table
     assert groupby in ('weighted_deciles',
@@ -891,8 +891,8 @@ def mtr_graph_data(vdf, year,
     # split dfx into groups specified by 'table_row' column
     gdfx = dfx.groupby('table_row', as_index=False)
     # apply the weighting_function to percentile-grouped mtr values
-    mtr1_series = gdfx.apply(weighting_function, 'mtr1')
-    mtr2_series = gdfx.apply(weighting_function, 'mtr2')
+    mtr1_series = gdfx.apply(weighting_function, 'mtr1').values[:, 1]
+    mtr2_series = gdfx.apply(weighting_function, 'mtr2').values[:, 1]
     # construct DataFrame containing the two mtr?_series
     lines = pd.DataFrame()
     lines['base'] = mtr1_series
@@ -1008,9 +1008,9 @@ def atr_graph_data(vdf, year,
     # split dfx into groups specified by 'table_row' column
     gdfx = dfx.groupby('table_row', as_index=False)
     # apply weighted_mean function to percentile-grouped values
-    avginc_series = gdfx.apply(weighted_mean, 'expanded_income')
-    avgtax1_series = gdfx.apply(weighted_mean, 'tax1')
-    avgtax2_series = gdfx.apply(weighted_mean, 'tax2')
+    avginc_series = gdfx.apply(weighted_mean, 'expanded_income').values[:, 1]
+    avgtax1_series = gdfx.apply(weighted_mean, 'tax1').values[:, 1]
+    avgtax2_series = gdfx.apply(weighted_mean, 'tax2').values[:, 1]
     # compute average tax rates for each included income percentile
     atr1_series = np.zeros(avginc_series.shape)
     atr1_series[included] = avgtax1_series[included] / avginc_series[included]
@@ -1176,8 +1176,8 @@ def pch_graph_data(vdf, year, pop_quantiles=False):
     # split dfx into groups specified by 'table_row' column
     gdfx = dfx.groupby('table_row', as_index=False)
     # apply weighted_mean function to percentile-grouped values
-    avginc_series = gdfx.apply(weighted_mean, 'expanded_income')
-    change_series = gdfx.apply(weighted_mean, 'chg_aftinc')
+    avginc_series = gdfx.apply(weighted_mean, 'expanded_income').values[:, 1]
+    change_series = gdfx.apply(weighted_mean, 'chg_aftinc').values[:, 1]
     # compute percentage change statistic each included income percentile
     pch_series = np.zeros(avginc_series.shape)
     pch_series[included] = change_series[included] / avginc_series[included]

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1025,9 +1025,15 @@ def atr_graph_data(vdf, year,
     avgtax2_series = gdfx.apply(weighted_mean, 'tax2').values[:, 1]
     # compute average tax rates for each included income percentile
     atr1_series = np.zeros(avginc_series.shape)
-    atr1_series[included] = avgtax1_series[included] / avginc_series[included]
+    atr1_series[included] = np.divide(
+        avgtax1_series[included], avginc_series[included],
+        out=np.zeros_like(avgtax1_series[included]),
+        where=avginc_series[included] != 0)
     atr2_series = np.zeros(avginc_series.shape)
-    atr2_series[included] = avgtax2_series[included] / avginc_series[included]
+    atr2_series[included] = np.divide(
+        avgtax2_series[included], avginc_series[included],
+        out=np.zeros_like(avgtax2_series[included]),
+        where=avginc_series[included] != 0)
     # construct DataFrame containing the two atr?_series
     lines = pd.DataFrame()
     lines['base'] = atr1_series
@@ -1192,7 +1198,10 @@ def pch_graph_data(vdf, year, pop_quantiles=False):
     change_series = gdfx.apply(weighted_mean, 'chg_aftinc').values[:, 1]
     # compute percentage change statistic each included income percentile
     pch_series = np.zeros(avginc_series.shape)
-    pch_series[included] = change_series[included] / avginc_series[included]
+    pch_series[included] = np.divide(
+        change_series[included], avginc_series[included],
+        out=np.zeros_like(change_series[included]),
+        where=avginc_series[included] != 0)
     # construct DataFrame containing the pch_series expressed as percent
     line = pd.DataFrame()
     line['pch'] = pch_series * 100

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -405,10 +405,16 @@ def create_distribution_table(vdf, groupby, income_measure,
                       'count_ItemDed',
                       'count_AMT']
         for col in dist_table.columns:
+            # if col in count_vars:
+            #     dist_table[col] = np.round(dist_table[col] * 1e-6, 2)
+            # else:
+            #     dist_table[col] = np.round(dist_table[col] * 1e-9, 3)
             if col in count_vars:
-                dist_table[col] = np.round(dist_table[col] * 1e-6, 2)
+                dist_table[col] *= 1e-6
+                dist_table.round({col: 2})
             else:
-                dist_table[col] = np.round(dist_table[col] * 1e-9, 3)
+                dist_table[col] *= 1e-9
+                dist_table.round({col: 3})
     # return table as Pandas DataFrame
     vdf.sort_index(inplace=True)
     return dist_table
@@ -478,14 +484,17 @@ def create_difference_table(vdf1, vdf2, groupby, tax_to_diff,
         # start of additive_stats_dataframe code
         sdf = pd.DataFrame()
         sdf['count'] = gdf.apply(unweighted_sum, 'count').values[:, 1]
-        sdf['tax_cut'] = gdf.apply(count_lt_zero, 'tax_diff').values[:, 1]
-        sdf['tax_inc'] = gdf.apply(count_gt_zero, 'tax_diff').values[:, 1]
-        sdf['tot_change'] = gdf.apply(weighted_sum, 'tax_diff').values[:, 1]
+        sdf['tax_cut'] = gdf.apply(count_lt_zero,
+                                   'tax_diff').values[:, 1]
+        sdf['tax_inc'] = gdf.apply(count_gt_zero,
+                                   'tax_diff').values[:, 1]
+        sdf['tot_change'] = gdf.apply(weighted_sum,
+                                      'tax_diff').values[:, 1]
         sdf['ubi'] = gdf.apply(weighted_sum, 'ubi').values[:, 1]
-        sdf['benefit_cost_total'] = gdf.apply(weighted_sum,
-                                              'benefit_cost_total').values[:, 1]
-        sdf['benefit_value_total'] = gdf.apply(weighted_sum,
-                                               'benefit_value_total').values[:, 1]
+        sdf['benefit_cost_total'] = gdf.apply(
+            weighted_sum, 'benefit_cost_total').values[:, 1]
+        sdf['benefit_value_total'] = gdf.apply(
+            weighted_sum, 'benefit_value_total').values[:, 1]
         sdf['atinc1'] = gdf.apply(weighted_sum, 'atinc1').values[:, 1]
         sdf['atinc2'] = gdf.apply(weighted_sum, 'atinc2').values[:, 1]
         return sdf
@@ -519,18 +528,15 @@ def create_difference_table(vdf1, vdf2, groupby, tax_to_diff,
         df2['count'] = df2['s006']
     # add table_row column to df2 given specified groupby and income_measure
     if groupby == 'weighted_deciles':
-        dframe = add_quantile_table_row_variable(df2,
-                                                 baseline_expanded_income, 10,
-                                                 pop_quantiles=pop_quantiles,
-                                                 decile_details=True)
+        dframe = add_quantile_table_row_variable(
+            df2, baseline_expanded_income, 10,
+            pop_quantiles=pop_quantiles, decile_details=True)
     elif groupby == 'standard_income_bins':
-        dframe = add_income_table_row_variable(df2,
-                                               baseline_expanded_income,
-                                               STANDARD_INCOME_BINS)
+        dframe = add_income_table_row_variable(
+            df2, baseline_expanded_income, STANDARD_INCOME_BINS)
     elif groupby == 'soi_agi_bins':
-        dframe = add_income_table_row_variable(df2,
-                                               baseline_expanded_income,
-                                               SOI_AGI_BINS)
+        dframe = add_income_table_row_variable(
+            df2, baseline_expanded_income, SOI_AGI_BINS)
     del df2
     # create grouped Pandas DataFrame
     gdf = dframe.groupby('table_row', as_index=False)
@@ -559,25 +565,30 @@ def create_difference_table(vdf1, vdf2, groupby, tax_to_diff,
     del gdf
     del dframe
     # compute non-additive stats in each table cell
-    count = diff_table['count']
-    diff_table['perc_cut'] = np.where(count > 0.,
-                                      100 * diff_table['tax_cut'] / count,
-                                      0.)
-    diff_table['perc_inc'] = np.where(count > 0.,
-                                      100 * diff_table['tax_inc'] / count,
-                                      0.)
-    diff_table['mean'] = np.where(count > 0.,
-                                  diff_table['tot_change'] / count,
-                                  0.)
+    count = diff_table['count'].values
+    diff_table['perc_cut'] = np.divide(
+        100 * diff_table['tax_cut'].values, count,
+        out=np.zeros_like(diff_table['tax_cut'].values),
+        where=count > 0)
+    diff_table['perc_inc'] = np.divide(
+        100 * diff_table['tax_inc'].values, count,
+        out=np.zeros_like(diff_table['tax_inc'].values),
+        where=count > 0)
+    diff_table['mean'] = np.divide(
+        diff_table['tot_change'].values, count,
+        out=np.zeros_like(diff_table['tot_change'].values),
+        where=count > 0)
     total_change = sum_row['tot_change']
-    diff_table['share_of_change'] = np.where(total_change == 0.,
-                                             np.nan,
-                                             (100 * diff_table['tot_change'] /
-                                              total_change))
-    diff_table['pc_aftertaxinc'] = np.where(diff_table['atinc1'] == 0.,
-                                            np.nan,
-                                            (100 * (diff_table['atinc2'] /
-                                                    diff_table['atinc1'] - 1)))
+    diff_table['share_of_change'] = np.divide(
+        100 * diff_table['tot_change'].values, total_change,
+        out=np.zeros_like(diff_table['tot_change'].values),
+        where=total_change > 0)
+    quotient = np.divide(
+        diff_table['atinc2'].values, diff_table['atinc1'],
+        out=np.zeros_like(diff_table['atinc2'].values),
+        where=diff_table['atinc1'] != 0)
+    diff_table['pc_aftertaxinc'] = np.where(
+        diff_table['atinc1'].values == 0., np.nan, 100 * (quotient - 1))
     # delete intermediate Pandas DataFrame objects
     del diff_table['atinc1']
     del diff_table['atinc2']
@@ -602,12 +613,13 @@ def create_difference_table(vdf1, vdf2, groupby, tax_to_diff,
                   'benefit_cost_total', 'benefit_value_total']
     for col in diff_table.columns:
         if col in count_vars:
-            diff_table[col] = np.round(diff_table[col] * 1e-6, 2)
+            diff_table[col] *= 1e-6
+            diff_table.round({col: 2})
         elif col in scale_vars:
-            diff_table[col] = np.round(diff_table[col] * 1e-9, 3)
+            diff_table[col] *= 1e-9
+            diff_table.round({col: 3})
         else:
-            diff_table[col] = np.round(diff_table[col], 1)
-    # return table as Pandas DataFrame
+            diff_table.round({col: 1})
     return diff_table
 
 


### PR DESCRIPTION
This PR replaces the `pytest-pep8` package used in the code style tests in Travis CI with `pytest-pycodestyle`.   Looking at [the history](https://bitbucket.org/pytest-dev/pytest-pep8/src/default/), `pytest-pep8` doesn't seem to have been updated since 2015 and it seems to be the issue with test failures on Travis-CI due to function deprecation.  `pytest-pycodestyle` seems to have similar functionality and continues to be supported.

In addition, the PR addresses changes in the Pandas API that are raising errors in Tax-Calc with Pandas 1.1.0.