### PR TITLE
Add ParamTools to dependencies in conda.recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - "bokeh>=1.4.0"
     - requests
     - numba
+    - paramtools
 
   run:
     - python
@@ -22,6 +23,7 @@ requirements:
     - "bokeh>=1.4.0"
     - requests
     - numba
+    - paramtools
 
 test:
   commands:


### PR DESCRIPTION
While testing out https://github.com/PSLmodels/Package-Builder/pull/175, I noticed that I forgot to include ParamTools in the dependencies section of the conda recipe configuration.