### PR TITLE
Require Paramtools >= 0.14.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - pycodestyle
 - pylint
 - coverage
-- "paramtools>=0.14.0"
+- "paramtools>=0.14.2"
 - pip
 - pip:
     - jupyter-book

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -37,7 +37,7 @@ def test_for_consistency(tests_path):
         'pycodestyle',
         'pylint',
         'coverage',
-        "paramtools>=0.14.0",
+        "paramtools>=0.14.2",
         "pip",
         "jupyter-book",
     ])


### PR DESCRIPTION
Paramtools 0.14.2 resolves error thrown by `make_uguide.py`.

This PR takes the place of #2423. I accidentally opened #2423 from a branch of `PSLmodels/Tax-Calculator` as opposed to `Peter-Metz/Tax-Calculator`.