### PR TITLE
Update Conda installation instructions

### DIFF
--- a/docs/usage/starting.md
+++ b/docs/usage/starting.md
@@ -26,7 +26,7 @@ Download a Tax-Calculator `taxcalc` package for your computer by executing
 this command from the command prompt:
 
 ```
-conda install -c PSLmodels taxcalc
+conda install -c PSLmodels -c conda-forge taxcalc
 ```
 
 This command will also install all the Python packages required by


### PR DESCRIPTION
Adds the `conda-forge` channel to the conda installation instructions.

If the user doesn't have `conda-forge` in their default set of conda channels, `conda install -c pslmodels taxcalc` will install `taxcalc` 2.9.

This issue was reported by @aelsibaie in #2481 