### PR TITLE
[WIP] Add parameters for refundable CDCC

### DIFF
--- a/docs/guide/output_vars.md
+++ b/docs/guide/output_vars.md
@@ -529,6 +529,13 @@ _IRS Form Location:_
 2013-20??: calculated variable  
 
 
+##  `cdcc_new`  
+_Description_: search taxcalc/calcfunctions.py for how calculated and used  
+_Datatype_: float  
+_IRS Form Location:_  
+2013-20??: calculated variable  
+
+
 ##  `odc`  
 _Description_: Other Dependent Credit  
 _Datatype_: float  

--- a/docs/guide/policy_params.md
+++ b/docs/guide/policy_params.md
@@ -3763,6 +3763,94 @@ _Valid Range:_ min = 0 and max = 1
 _Out-of-Range Action:_ error  
 
 
+### Refundable Child and Dependent Care Credit
+
+####  `CDCC_new_c`  
+_Description:_ The maximum refundable credit allowed for each qualifying dependent.  
+_Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
+_Can Be Inflation Indexed:_ True _Is Inflation Indexed:_ True  
+_Value Type:_ float  
+_Known Values:_  
+2013: 0.0  
+2014: 0.0  
+2015: 0.0  
+2016: 0.0  
+2017: 0.0  
+2018: 0.0  
+2019: 0.0  
+_Valid Range:_ min = 0 and max = 9e+99  
+_Out-of-Range Action:_ error  
+
+
+####  `CDCC_new_deps_max`  
+_Description:_ The refundable child & dependent care credit will be applied up to this many dependents.  
+_Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
+_Can Be Inflation Indexed:_ False _Is Inflation Indexed:_ False  
+_Value Type:_ int  
+_Known Values:_  
+2013: 10  
+2014: 10  
+2015: 10  
+2016: 10  
+2017: 10  
+2018: 10  
+2019: 10  
+_Valid Range:_ min = 0 and max = 10  
+_Out-of-Range Action:_ error  
+
+
+####  `CDCC_new_frac`  
+_Description:_ Child care costs are multiplied by this fraction to calculate the refundable child & dependent care credit amount.  
+_Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
+_Can Be Inflation Indexed:_ False _Is Inflation Indexed:_ False  
+_Value Type:_ float  
+_Known Values:_  
+2013: 1.0  
+2014: 1.0  
+2015: 1.0  
+2016: 1.0  
+2017: 1.0  
+2018: 1.0  
+2019: 1.0  
+_Valid Range:_ min = 0 and max = 1.0  
+_Out-of-Range Action:_ error  
+
+
+####  `CDCC_new_ps`  
+_Description:_ The total amount of the refundable child & dependent care credit is reduced for taxpayers with AGI higher than this level.  
+_Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
+_Can Be Inflation Indexed:_ True _Is Inflation Indexed:_ True  
+_Value Type:_ float  
+_Known Values:_  
+ for: [single, mjoint, mseparate, headhh, widow]  
+2013: [0.0, 0.0, 0.0, 0.0, 0.0]  
+2014: [0.0, 0.0, 0.0, 0.0, 0.0]  
+2015: [0.0, 0.0, 0.0, 0.0, 0.0]  
+2016: [0.0, 0.0, 0.0, 0.0, 0.0]  
+2017: [0.0, 0.0, 0.0, 0.0, 0.0]  
+2018: [0.0, 0.0, 0.0, 0.0, 0.0]  
+2019: [0.0, 0.0, 0.0, 0.0, 0.0]  
+_Valid Range:_ min = 0 and max = 9e+99  
+_Out-of-Range Action:_ error  
+
+
+####  `CDCC_new_prt`  
+_Description:_ The total amount of the refundable child & dependent care credit is reduced at this rate per dollar exceeding the phaseout starting AGI, CDCC_new_ps.  
+_Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
+_Can Be Inflation Indexed:_ False _Is Inflation Indexed:_ False  
+_Value Type:_ float  
+_Known Values:_  
+2013: 0.0  
+2014: 0.0  
+2015: 0.0  
+2016: 0.0  
+2017: 0.0  
+2018: 0.0  
+2019: 0.0  
+_Valid Range:_ min = 0 and max = 9e+99  
+_Out-of-Range Action:_ error  
+
+
 ### Refundable Payroll Tax Credit
 
 ####  `RPTC_c`  

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -16,7 +16,7 @@ from taxcalc.calcfunctions import (TaxInc, SchXYZTax, GainsTax, AGIsurtax,
                                    DependentCare, ALD_InvInc_ec_base, CapGains,
                                    SSBenefits, UBI, AGI, ItemDedCap, ItemDed,
                                    StdDed, AdditionalMedicareTax, F2441, EITC,
-                                   RefundablePayrollTaxCredit,
+                                   RefundablePayrollTaxCredit, CDCC_new,
                                    ChildDepTaxCredit, AdditionalCTC, CTC_new,
                                    PersonalTaxCredit, SchR,
                                    AmOppCreditParts, EducationTaxCredit,
@@ -1444,4 +1444,5 @@ class Calculator():
         AdditionalCTC(self.__policy, self.__records)
         C1040(self.__policy, self.__records)
         CTC_new(self.__policy, self.__records)
+        CDCC_new(self.__policy, self.__records)
         IITAX(self.__policy, self.__records)

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -15239,7 +15239,7 @@
     "CDCC_new_c": {
         "title": "Maximum refundable child & dependent care credit per dependent",
         "description": "The maximum refundable credit allowed for each qualifying dependent.",
-        "notes": "",
+        "notes": "Child/dependent care expenses (e32800) reported in the PUF and CPS files are capped. Therefore, CDCC_new_* should not be used with the PUF or CPS files.",
         "section_1": "Refundable Credits",
         "section_2": "Refundable Child and Dependent Care Credit",
         "indexable": true,
@@ -15282,14 +15282,14 @@
             }
         },
         "compatible_data": {
-            "puf": true,
-            "cps": true
+            "puf": false,
+            "cps": false
         }
     },
     "CDCC_new_deps_max": {
         "title": "Maximum number of children eligible for refundable child & dependent care credit",
         "description": "The refundable child & dependent care credit will be applied up to this many dependents.",
-        "notes": "",
+        "notes": "Child/dependent care expenses (e32800) reported in the PUF and CPS files are capped. Therefore, CDCC_new_* should not be used with the PUF or CPS files.",
         "section_1": "Refundable Credits",
         "section_2": "Refundable Child and Dependent Care Credit",
         "indexable": false,
@@ -15308,14 +15308,14 @@
             }
         },
         "compatible_data": {
-            "puf": true,
-            "cps": true
+            "puf": false,
+            "cps": false
         }
     },
     "CDCC_new_frac": {
         "title": "Fraction of child care costs eligible for refundable child & dependent care credit",
         "description": "Child care costs are multiplied by this fraction to calculate the refundable child & dependent care credit amount.",
-        "notes": "",
+        "notes": "Child/dependent care expenses (e32800) reported in the PUF and CPS files are capped. Therefore, CDCC_new_* should not be used with the PUF or CPS files.",
         "section_1": "Refundable Credits",
         "section_2": "Refundable Child and Dependent Care Credit",
         "indexable": false,
@@ -15334,14 +15334,14 @@
             }
         },
         "compatible_data": {
-            "puf": true,
-            "cps": true
+            "puf": false,
+            "cps": false
         }
     },
     "CDCC_new_ps": {
         "title": "Refundable child & dependent care credit phaseout starting AGI",
         "description": "The total amount of the refundable child & dependent care credit is reduced for taxpayers with AGI higher than this level.",
-        "notes": "",
+        "notes": "Child/dependent care expenses (e32800) reported in the PUF and CPS files are capped. Therefore, CDCC_new_* should not be used with the PUF or CPS files.",
         "section_1": "Refundable Credits",
         "section_2": "Refundable Child and Dependent Care Credit",
         "indexable": true,
@@ -15531,14 +15531,14 @@
             }
         },
         "compatible_data": {
-            "puf": true,
-            "cps": true
+            "puf": false,
+            "cps": false
         }
     },
     "CDCC_new_prt": {
         "title": "Refundable child & dependent care credit phaseout rate",
         "description": "The total amount of the refundable child & dependent care credit is reduced at this rate per dollar exceeding the phaseout starting AGI, CDCC_new_ps.",
-        "notes": "",
+        "notes": "Child/dependent care expenses (e32800) reported in the PUF and CPS files are capped. Therefore, CDCC_new_* should not be used with the PUF or CPS files.",
         "section_1": "Refundable Credits",
         "section_2": "Refundable Child and Dependent Care Credit",
         "indexable": false,
@@ -15557,8 +15557,8 @@
             }
         },
         "compatible_data": {
-            "puf": true,
-            "cps": true
+            "puf": false,
+            "cps": false
         }
     },           
     "FST_AGI_trt": {

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -15236,6 +15236,331 @@
             "cps": true
         }
     },
+    "CDCC_new_c": {
+        "title": "Maximum refundable child & dependent care credit per dependent",
+        "description": "The maximum refundable credit allowed for each qualifying dependent.",
+        "notes": "",
+        "section_1": "Refundable Credits",
+        "section_2": "Refundable Child and Dependent Care Credit",
+        "indexable": true,
+        "indexed": true,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "value": 0.0
+            },
+            {
+                "year": 2019,
+                "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "CDCC_new_deps_max": {
+        "title": "Maximum number of children eligible for refundable child & dependent care credit",
+        "description": "The refundable child & dependent care credit will be applied up to this many dependents.",
+        "notes": "",
+        "section_1": "Refundable Credits",
+        "section_2": "Refundable Child and Dependent Care Credit",
+        "indexable": false,
+        "indexed": false,
+        "type": "int",
+        "value": [
+            {
+                "year": 2013,
+                "value": 10
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 10
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "CDCC_new_frac": {
+        "title": "Fraction of child care costs eligible for refundable child & dependent care credit",
+        "description": "Child care costs are multiplied by this fraction to calculate the refundable child & dependent care credit amount.",
+        "notes": "",
+        "section_1": "Refundable Credits",
+        "section_2": "Refundable Child and Dependent Care Credit",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 1.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1.0
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "CDCC_new_ps": {
+        "title": "Refundable child & dependent care credit phaseout starting AGI",
+        "description": "The total amount of the refundable child & dependent care credit is reduced for taxpayers with AGI higher than this level.",
+        "notes": "",
+        "section_1": "Refundable Credits",
+        "section_2": "Refundable Child and Dependent Care Credit",
+        "indexable": true,
+        "indexed": true,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "widow",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "widow",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "widow",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "widow",
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "MARS": "widow",
+                "value": 0.0
+            },
+            {
+                "year": 2019,
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2019,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2019,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2019,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2019,
+                "MARS": "widow",
+                "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "CDCC_new_prt": {
+        "title": "Refundable child & dependent care credit phaseout rate",
+        "description": "The total amount of the refundable child & dependent care credit is reduced at this rate per dollar exceeding the phaseout starting AGI, CDCC_new_ps.",
+        "notes": "",
+        "section_1": "Refundable Credits",
+        "section_2": "Refundable Child and Dependent Care Credit",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },           
     "FST_AGI_trt": {
         "title": "New minimum tax; rate as a decimal fraction of AGI",
         "description": "Individual income taxes and the employee share of payroll taxes are credited against this minimum tax, so the surtax is the difference between the tax rate times AGI and the credited taxes. The new minimum tax is similar to the Fair Share Tax, except that no credits are exempted from the base.",

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -1030,6 +1030,11 @@
       "desc": "search taxcalc/calcfunctions.py for how calculated and used",
       "form": {"2013-20??": "calculated variable"}
     },
+    "cdcc_new": {
+      "type": "float",
+      "desc": "search taxcalc/calcfunctions.py for how calculated and used",
+      "form": {"2013-20??": "calculated variable"}
+    },
     "odc": {
       "type": "float",
       "desc": "Other Dependent Credit",

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -707,6 +707,7 @@ def test_section_titles(tests_path):
         'Refundable Credits': {
             'Earned Income Tax Credit': 0,
             'New Refundable Child Tax Credit': 0,
+            'Refundable Child and Dependent Care Credit': 0,
             'Personal Refundable Credit': 0,
             'Refundable Payroll Tax Credit': 0
         },


### PR DESCRIPTION
This PR adds the tax logic and parameters for computing a fully refundable child and dependent care credit, as proposed by Joe Biden:

![Screen Shot 2020-10-30 at 8 39 57 AM](https://user-images.githubusercontent.com/43755005/97706121-8b9c8880-1a8b-11eb-8849-9961a918b67c.png)

([source](https://joebiden.com/caregiving/#))

Here are the distributional effects in 2021 of implementing Biden's CDCC provision (assuming that the new CDCC replaces the original, non-refundable CDCC):

![Screen Shot 2020-10-30 at 8 44 47 AM](https://user-images.githubusercontent.com/43755005/97706491-2e550700-1a8c-11eb-929a-340cbedb45ef.png)

