### PR TITLE
Add parameters for QBI deduction phaseout

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -839,9 +839,8 @@ def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, e26270,
         qbided = min(qbided, taxinc_cap)
 
         # apply qbid phaseout
-        modAGI = c00100
-        if qbided > 0. and modAGI > PT_qbid_ps[MARS - 1]:
-            excess = modAGI - PT_qbid_ps[MARS - 1]
+        if qbided > 0. and pre_qbid_taxinc > PT_qbid_ps[MARS - 1]:
+            excess = pre_qbid_taxinc - PT_qbid_ps[MARS - 1]
             qbided = max(0., qbided - PT_qbid_prt * excess)
 
     # calculate taxable income after qualified business income deduction

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -792,7 +792,7 @@ def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, e26270,
            PT_binc_w2_wages, PT_ubia_property, PT_qbid_rt,
            PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
            PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800,
-           PT_qbid_ps, PT_qbid_prt, qbided):
+           PT_qbid_ps, PT_qbid_prt, qbided, PT_qbid_limit_switch):
     """
     Calculates taxable income, c04800, and
     qualified business income deduction, qbided.

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -788,12 +788,11 @@ def StdDed(DSI, earned, STD, age_head, age_spouse, STD_Aged, STD_Dep,
 
 @iterate_jit(nopython=True)
 def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, e26270,
-           e02100, e27200, e00650, c01000,
-           PT_SSTB_income, PT_binc_w2_wages, PT_ubia_property,
-           PT_qbid_rt, PT_qbid_taxinc_thd, PT_qbid_taxinc_gap,
-           PT_qbid_w2_wages_rt,
-           PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt,
-           c04800, qbided):
+           e02100, e27200, e00650, c01000, PT_SSTB_income,
+           PT_binc_w2_wages, PT_ubia_property, PT_qbid_rt,
+           PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
+           PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800,
+           PT_qbid_ps, PT_qbid_prt, qbided):
     """
     Calculates taxable income, c04800, and
     qualified business income deduction, qbided.
@@ -838,6 +837,13 @@ def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, e26270,
         net_cg = e00650 + c01000  # per line 34 in 2018 Pub 535 Worksheet 12-A
         taxinc_cap = PT_qbid_rt * max(0., pre_qbid_taxinc - net_cg)
         qbided = min(qbided, taxinc_cap)
+
+        # apply qbid phaseout
+        modAGI = c00100
+        if qbided > 0. and modAGI > PT_qbid_ps[MARS - 1]:
+            excess = modAGI - PT_qbid_ps[MARS - 1]
+            qbided = max(0., qbided - PT_qbid_prt * excess)
+
     # calculate taxable income after qualified business income deduction
     c04800 = max(0., pre_qbid_taxinc - qbided)
     return (c04800, qbided)

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -12359,8 +12359,8 @@
         }
     },
     "PT_qbid_ps": {
-        "title": "QBID phaseout AGI start",
-        "description": "QBID begins to decrease when AGI is above this level.",
+        "title": "QBID phaseout taxable income start",
+        "description": "QBID begins to decrease when pre-QBID taxable income is above this level.",
         "notes": "",
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
@@ -12557,7 +12557,7 @@
     },
     "PT_qbid_prt": {
         "title": "QBID phaseout rate",
-        "description": "QBID will decrease at this rate for each dollar of AGI exceeding QBID phaseout start.",
+        "description": "QBID will decrease at this rate for each dollar of taxable income exceeding QBID phaseout start.",
         "notes": "",
         "section_1": "Personal Income",
         "section_2": "Pass-Through",

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -12358,6 +12358,253 @@
             "cps": false
         }
     },
+    "PT_qbid_ps": {
+        "title": "QBID phaseout AGI start",
+        "description": "QBID begins to decrease when AGI is above this level.",
+        "notes": "",
+        "section_1": "Personal Income",
+        "section_2": "Pass-Through",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 9e99
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 9e99
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 9e99
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 9e99
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 9e99
+            },
+            {
+                "year": 2014,
+                "MARS": "single",
+                "value": 9e99
+            },
+            {
+                "year": 2014,
+                "MARS": "mjoint",
+                "value": 9e99
+            },
+            {
+                "year": 2014,
+                "MARS": "mseparate",
+                "value": 9e99
+            },
+            {
+                "year": 2014,
+                "MARS": "headhh",
+                "value": 9e99
+            },
+            {
+                "year": 2014,
+                "MARS": "widow",
+                "value": 9e99
+            },
+            {
+                "year": 2015,
+                "MARS": "single",
+                "value": 9e99
+            },
+            {
+                "year": 2015,
+                "MARS": "mjoint",
+                "value": 9e99
+            },
+            {
+                "year": 2015,
+                "MARS": "mseparate",
+                "value": 9e99
+            },
+            {
+                "year": 2015,
+                "MARS": "headhh",
+                "value": 9e99
+            },
+            {
+                "year": 2015,
+                "MARS": "widow",
+                "value": 9e99
+            },
+            {
+                "year": 2016,
+                "MARS": "single",
+                "value": 9e99
+            },
+            {
+                "year": 2016,
+                "MARS": "mjoint",
+                "value": 9e99
+            },
+            {
+                "year": 2016,
+                "MARS": "mseparate",
+                "value": 9e99
+            },
+            {
+                "year": 2016,
+                "MARS": "headhh",
+                "value": 9e99
+            },
+            {
+                "year": 2016,
+                "MARS": "widow",
+                "value": 9e99
+            },
+            {
+                "year": 2017,
+                "MARS": "single",
+                "value": 9e99
+            },
+            {
+                "year": 2017,
+                "MARS": "mjoint",
+                "value": 9e99
+            },
+            {
+                "year": 2017,
+                "MARS": "mseparate",
+                "value": 9e99
+            },
+            {
+                "year": 2017,
+                "MARS": "headhh",
+                "value": 9e99
+            },
+            {
+                "year": 2017,
+                "MARS": "widow",
+                "value": 9e99
+            },
+            {
+                "year": 2018,
+                "MARS": "single",
+                "value": 9e99
+            },
+            {
+                "year": 2018,
+                "MARS": "mjoint",
+                "value": 9e99
+            },
+            {
+                "year": 2018,
+                "MARS": "mseparate",
+                "value": 9e99
+            },
+            {
+                "year": 2018,
+                "MARS": "headhh",
+                "value": 9e99
+            },
+            {
+                "year": 2018,
+                "MARS": "widow",
+                "value": 9e99
+            },
+            {
+                "year": 2019,
+                "MARS": "single",
+                "value": 9e99
+            },
+            {
+                "year": 2019,
+                "MARS": "mjoint",
+                "value": 9e99
+            },
+            {
+                "year": 2019,
+                "MARS": "mseparate",
+                "value": 9e99
+            },
+            {
+                "year": 2019,
+                "MARS": "headhh",
+                "value": 9e99
+            },
+            {
+                "year": 2019,
+                "MARS": "widow",
+                "value": 9e99
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "PT_qbid_prt": {
+        "title": "QBID phaseout rate",
+        "description": "QBID will decrease at this rate for each dollar of AGI exceeding QBID phaseout start.",
+        "notes": "",
+        "section_1": "Personal Income",
+        "section_2": "Pass-Through",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "value": 0.0
+            },
+            {
+                "year": 2019,
+                "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e99
+            }
+        },
+        "compatible_data": {
+            "puf": false,
+            "cps": false
+        }
+    },
     "AMT_em": {
         "title": "AMT exemption amount",
         "description": "The amount of AMT taxable income exempted from AMT.",

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -12365,7 +12365,7 @@
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
         "indexable": true,
-        "indexed": false,
+        "indexed": true,
         "type": "float",
         "value": [
             {
@@ -12601,8 +12601,8 @@
             }
         },
         "compatible_data": {
-            "puf": false,
-            "cps": false
+            "puf": true,
+            "cps": true
         }
     },
     "AMT_em": {


### PR DESCRIPTION
This PR adds two parameters to model a phaseout of the QBI deduction, `PT_qbid_ps` and `PT_qbid_prt`, based on taxable income.

Biden has proposed a phaseout of the QBI deduction for those with taxable income > $400,000, although he has not specified the phaseout rate.

Since the wage and capital restrictions are fully enforced in Tax-Calculator for all taxpayers (see #2385 and PSLmodels/taxdata#319), implementing Biden's phaseout has little revenue effect. 