### PR TITLE
Allow for unit tests without decorators

### DIFF
--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -243,6 +243,7 @@ def iterate_jit(parameters=None, **kwargs):
     transforms the calc-style function into an apply-style function that
     can be called by Calculator class methods (see calculator.py).
     """
+
     if not parameters:
         parameters = []
 
@@ -299,6 +300,9 @@ def iterate_jit(parameters=None, **kwargs):
             wrapper function nested in make_wrapper function nested
             in iterate_jit decorator.
             """
+            if os.getenv('TESTING') == 'True': # os TESTING environment only accepts string arguments
+                return func(*args, **kwargs)
+
             in_arrays = []
             pm_or_pf = []
             for farg in all_out_args + in_args:

--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 # convert all numpy warnings into errors so they can be detected in tests
 numpy.seterr(all='raise')
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def skip_jit(monkeypatch):
     monkeypatch.setenv("TESTING", "True")
     yield

--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 # convert all numpy warnings into errors so they can be detected in tests
 numpy.seterr(all='raise')
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def skip_jit(monkeypatch):
     monkeypatch.setenv("TESTING", "True")
     yield

--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -9,6 +9,10 @@ import pytest
 # convert all numpy warnings into errors so they can be detected in tests
 numpy.seterr(all='raise')
 
+@pytest.fixture
+def skip_jit(monkeypatch):
+    monkeypatch.setenv("TESTING", "True")
+    yield
 
 @pytest.fixture(scope='session')
 def tests_path():

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -11,8 +11,7 @@ import ast
 from taxcalc import Records  # pylint: disable=import-error
 from taxcalc import calcfunctions
 import numpy as np
-
-os.environ['TESTING'] = 'True' # os TESTING environment only accepts string arguments
+import pytest
 
 
 class GetFuncDefs(ast.NodeVisitor):
@@ -165,3 +164,17 @@ def test_function_args_usage(tests_path):
                 msg += 'FUNCTION,ARGUMENT= {} {}\n'.format(fname, arg)
     if found_error:
         raise ValueError(msg)
+
+
+def test_DependentCare(monkeypatch):
+    """
+    Tests the DependentCare function
+    """
+    monkeypatch.setenv("TESTING", "True")
+
+    test_tuple = (3, 2, 100000, 1, [250000, 500000, 250000, 500000, 250000], 
+                  .2, 7165, 5000, 0)
+    test_value = calcfunctions.DependentCare(*test_tuple)
+    expected_value = 25196
+
+    assert np.allclose(test_value, expected_value)

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -166,11 +166,10 @@ def test_function_args_usage(tests_path):
         raise ValueError(msg)
 
 
-def test_DependentCare(monkeypatch):
+def test_DependentCare(skip_jit):
     """
     Tests the DependentCare function
     """
-    monkeypatch.setenv("TESTING", "True")
 
     test_tuple = (3, 2, 100000, 1, [250000, 500000, 250000, 500000, 250000], 
                   .2, 7165, 5000, 0)

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -9,6 +9,10 @@ import os
 import re
 import ast
 from taxcalc import Records  # pylint: disable=import-error
+from taxcalc import calcfunctions
+import numpy as np
+
+os.environ['TESTING'] = 'True' # os TESTING environment only accepts string arguments
 
 
 class GetFuncDefs(ast.NodeVisitor):


### PR DESCRIPTION
This PR addresses a problem that @jdebacker had with creating unit tests for `calcfunctions.py` without decorators (#2489).

Using `pytest` with functions in `calcfunctions.py` is possible if the `iterate_jit` decorator is removed, so the decorator will now simply return the passed function with no wrapper if the OS environment variable for `TESTING` is set to `'True'` (as a string, the environment variable only accepts strings) in `test_calcfunctions.py`.

The test function `test_DependentCare()` provided in #2489 passes with this change.

---
This also enables unit testing discussed in #2419.