### PR TITLE
Check for existence of reform and assumption json files

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1087,7 +1087,7 @@ class Calculator():
         The 'growdiff_response' subdictionary of the returned dictionary is
         suitable as input into the GrowDiff.update_growdiff method.
         """
-        # check for existence of reform
+        # check for existence of reform and assumption files
         if not os.path.isfile(reform):
             raise ValueError("This .json reform file does not exist or this is a misspecified directory.")
         if not os.path.isfile(assump):

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -8,7 +8,6 @@ Tax-Calculator federal income and payroll tax Calculator class.
 # pylint: disable=too-many-lines,no-value-for-parameter
 
 import copy
-import os
 import numpy as np
 import pandas as pd
 import paramtools
@@ -1087,12 +1086,6 @@ class Calculator():
         The 'growdiff_response' subdictionary of the returned dictionary is
         suitable as input into the GrowDiff.update_growdiff method.
         """
-        # check for existence of reform and assumption files
-        if not os.path.isfile(reform):
-            raise ValueError("This .json reform file does not exist or this is a misspecified directory.")
-        if not os.path.isfile(assump):
-            raise ValueError("This .json assumptions file does not exist or this is a misspecified directory.")
-        # construct the composite dictionary
         param_dict = dict()
         param_dict['policy'] = Policy.read_json_reform(reform)
         param_dict['consumption'] = Consumption.read_json_update(assump)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -8,6 +8,7 @@ Tax-Calculator federal income and payroll tax Calculator class.
 # pylint: disable=too-many-lines,no-value-for-parameter
 
 import copy
+import os
 import numpy as np
 import pandas as pd
 import paramtools
@@ -1086,6 +1087,11 @@ class Calculator():
         The 'growdiff_response' subdictionary of the returned dictionary is
         suitable as input into the GrowDiff.update_growdiff method.
         """
+        # check for existence of reform
+        if not os.path.isfile(reform):
+            raise ValueError("This .json reform file does not exist or this is a misspecified directory.")
+        if not os.path.isfile(assump):
+            raise ValueError("This .json assumptions file does not exist or this is a misspecified directory.")
         # construct the composite dictionary
         param_dict = dict()
         param_dict['policy'] = Policy.read_json_reform(reform)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1086,6 +1086,7 @@ class Calculator():
         The 'growdiff_response' subdictionary of the returned dictionary is
         suitable as input into the GrowDiff.update_growdiff method.
         """
+        # construct the composite dictionary
         param_dict = dict()
         param_dict['policy'] = Policy.read_json_reform(reform)
         param_dict['consumption'] = Consumption.read_json_update(assump)

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -700,9 +700,9 @@ class Parameters(pt.Parameters):
                 elif ("{" and "}") in obj:
                     txt = obj
                 else:
-                    raise ValueError("The .json file or variable does not exist or is misspecified.")
+                    raise OSError("The .json file or variable does not exist or is misspecified.")
             else:
-                raise ValueError("The .json file or variable does not exist or is misspecified.")
+                raise OSError("The .json file or variable does not exist or is misspecified.")
         # strip out //-comments without changing line numbers
         json_txt = re.sub('//.*', ' ', txt)
         # convert JSON text into a Python dictionary

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -693,16 +693,18 @@ class Parameters(pt.Parameters):
             txt = req.text
         else:
             if isinstance(topkey, str) and (topkey == ''):
-                raise ValueError("String is empty.")
+                raise ValueError("topkey string is empty.")
             if isinstance(obj, str):
                 if obj == '':
-                    raise ValueError("String is empty.")    
+                    raise ValueError("obj string is empty.")    
+                elif obj.endswith('.json') and not os.path.isfile(obj):
+                    raise FileNotFoundError("The .json file does not exist.")
                 elif ("{" and "}") in obj:
                     txt = obj
                 else:
-                    raise OSError("The .json file or variable does not exist or is misspecified.")
+                    raise ValueError("The JSON variable is misspecified.")
             else:
-                raise OSError("The .json file or variable does not exist or is misspecified.")
+                raise ValueError("The JSON variable is misspecified.")
         # strip out //-comments without changing line numbers
         json_txt = re.sub('//.*', ' ', txt)
         # convert JSON text into a Python dictionary

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -697,7 +697,7 @@ class Parameters(pt.Parameters):
             if isinstance(obj, str):
                 if obj == '':
                     raise ValueError("String is empty.")    
-                elif ("{" or "}") in obj:
+                elif ("{" and "}") in obj:
                     txt = obj
                 else:
                     raise ValueError("The .json file or variable does not exist or is misspecified.")

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -692,7 +692,17 @@ class Parameters(pt.Parameters):
             req.raise_for_status()
             txt = req.text
         else:
-            txt = obj
+            if isinstance(topkey, str) and (topkey == ''):
+                raise ValueError("String is empty.")
+            if isinstance(obj, str):
+                if obj == '':
+                    raise ValueError("String is empty.")    
+                elif ("{" or "}") in obj:
+                    txt = obj
+                else:
+                    raise ValueError("The .json file or variable does not exist or is misspecified.")
+            else:
+                raise ValueError("The .json file or variable does not exist or is misspecified.")
         # strip out //-comments without changing line numbers
         json_txt = re.sub('//.*', ' ', txt)
         # convert JSON text into a Python dictionary

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -504,7 +504,7 @@ def test_read_bad_json_assump_file():
     """
     with pytest.raises(ValueError):
         Calculator.read_json_param_objects(None, badassump1)
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         Calculator.read_json_param_objects(None, 'unknown_file_name')
     with pytest.raises(ValueError):
         Calculator.read_json_param_objects(None, list())
@@ -514,9 +514,9 @@ def test_json_doesnt_exist():
     """
     Test JSON file which doesn't exist
     """
-    with pytest.raises(OSError):
+    with pytest.raises(FileNotFoundError):
         Calculator.read_json_param_objects(None, './reforms/doesnt_exist.json')
-    with pytest.raises(OSError):
+    with pytest.raises(FileNotFoundError):
         Calculator.read_json_param_objects('./reforms/doesnt_exist.json', None)
 
 

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -504,10 +504,20 @@ def test_read_bad_json_assump_file():
     """
     with pytest.raises(ValueError):
         Calculator.read_json_param_objects(None, badassump1)
-    with pytest.raises(ValueError):
+    with pytest.raises(OSError):
         Calculator.read_json_param_objects(None, 'unknown_file_name')
     with pytest.raises(ValueError):
         Calculator.read_json_param_objects(None, list())
+
+
+def test_json_doesnt_exist():
+    """
+    Test JSON file which doesn't exist
+    """
+    with pytest.raises(OSError):
+        Calculator.read_json_param_objects(None, './reforms/doesnt_exist.json')
+    with pytest.raises(OSError):
+        Calculator.read_json_param_objects('./reforms/doesnt_exist.json', None)
 
 
 def test_calc_all():


### PR DESCRIPTION
This PR adds checks in the `Parameters` method `_read_json_revision` to check for the existence and validity of reform and assumption files. Addresses #2518.

cc @MaxGhenis 