### PR TITLE
[Review Ready] Raise error when data has more records than weights

### DIFF
--- a/taxcalc/data.py
+++ b/taxcalc/data.py
@@ -100,7 +100,9 @@ class Data():
             if self.__aging_data:
                 self._read_weights(weights)
                 # ... weights must be same size as data
-                if self.array_length != len(self.WT.index):
+                if self.array_length > len(self.WT.index):
+                    raise ValueError("Data has more records than weights.")
+                elif self.array_length < len(self.WT.index):
                     # scale-up sub-sample weights by year-specific factor
                     sum_full_weights = self.WT.sum()
                     self.WT = self.WT.iloc[self.__index]


### PR DESCRIPTION
This PR addressed #2436. When trying to instantiate a `Records` object with data that has more records then the passed weights file, a clear error is thrown.