### PR TITLE
Update paramtools in conda environments + pre-release fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ TAXCALC_JSON_FILES := $(shell ls -l ./taxcalc/*json | awk '{print $$9}')
 TESTS_JSON_FILES := $(shell ls -l ./taxcalc/tests/*json | awk '{print $$9}')
 PYLINT_FILES := $(shell grep -rl --include="*py" disable=locally-disabled .)
 PYLINT_OPTIONS = --disable=locally-disabled --score=no --jobs=4
-RECIPE_FILES := $(shell ls -l ./docs/cookbook/recipe*ipynb | awk '{print $$9}')
+RECIPE_FILES := $(shell ls -l ./docs/recipes/recipe*.ipynb | awk '{print $$9}')
 PYLINT_IGNORE = C0103,C0111,E0401,E1120,R0913,R0914,W0401,W0614
 RECIPE_OPTIONS = --disable=$(PYLINT_IGNORE) --score=no --jobs=4
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - "bokeh>=1.4.0"
     - requests
     - numba
-    - "paramtools>=0.17.0"
+    - "paramtools>=0.18.0"
     - aiohttp
 
   run:
@@ -24,7 +24,7 @@ requirements:
     - "bokeh>=1.4.0"
     - requests
     - numba
-    - "paramtools>=0.17.0"
+    - "paramtools>=0.18.0"
     - aiohttp
 
 test:

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pycodestyle
 - pylint
 - coverage
-- "paramtools>=0.17.0"
+- "paramtools>=0.18.0"
 - pip
 - pip:
     - jupyter-book


### PR DESCRIPTION
This PR updates `environment.yml` and `meta.yaml` to require `paramtools>=0.18` for features in #2557 to run smoothly.

cc @MattHJensen