### PR TITLE
Update read invalid JSON file to read from an existing invalid file

### DIFF
--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -391,15 +391,20 @@ def test_bad_json_names(tests_path):
     """
     Test that ValueError raised with assump or reform do not end in '.json'
     """
+    test_url = (
+        'https://raw.githubusercontent.com/PSLmodels/'
+        'Tax-Calculator/master/taxcalc/reforms/'
+        '2017_law.out.csv'
+    )
     csvname = os.path.join(tests_path, '..', 'growfactors.csv')
     with pytest.raises(ValueError):
         Calculator.read_json_param_objects(csvname, None)
-    with pytest.raises(FileNotFoundError):
-        Calculator.read_json_param_objects('http://name.json.html', None)
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_objects(test_url, None)
     with pytest.raises(ValueError):
         Calculator.read_json_param_objects(None, csvname)
-    with pytest.raises(FileNotFoundError):
-        Calculator.read_json_param_objects(None, 'http://name.json.html')
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_objects(None, test_url)
 
 
 def test_json_assump_url():


### PR DESCRIPTION
- Updates `test_bad_json_names` to test reading an _existing_ file with an invalid format instead of a non-existent one. Prior to #2557, Tax-Calculator would declare the file invalid based on the file extension, but now it will try to pull the file down and load it first.
- Fixes an error reported by @MattHJensen:
```
_________________________________________________________________________________ test_bad_json_names __________________________________________________________________________________

params_or_path = 'http://name.json.html', storage_options = None

    def read_json(
        params_or_path: FileDictStringLike,
        storage_options: Optional[Dict[str, Any]] = None,
    ):
        """
        Read JSON data of the form:
        - Dict.
        - JSON string.
        - Local file path.
        - Any URL readable by fsspec. For example:
          - s3: s3://paramtools-test/defaults.json
          - gcs: gs://paramtools-dev/defaults.json
          - http: https://somedomain.com/defaults.json
          - github: github://PSLmodels:ParamTools@master/paramtools/tests/defaults.json
    
        """
        res = _read(params_or_path, storage_options)
        if isinstance(res, str):
            try:
                res = remove_comments(res)
>               return json.loads(res, object_pairs_hook=OrderedDict)

../../anaconda3/envs/taxcalc-dev/lib/python3.8/site-packages/paramtools/utils.py:109: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

s = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.d...e.clientHeight||b.clientHeight;url+="&w="+x+"&h="+y;}window.location.replace(url);</script></head><body></body></html>'
cls = <class 'json.decoder.JSONDecoder'>, object_hook = None, parse_float = None, parse_int = None, parse_constant = None, object_pairs_hook = <class 'collections.OrderedDict'>
kw = {'object_pairs_hook': <class 'collections.OrderedDict'>}

    def loads(s, *, cls=None, object_hook=None, parse_float=None,
            parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
        """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
        containing a JSON document) to a Python object.
    
        ``object_hook`` is an optional function that will be called with the
        result of any object literal decode (a ``dict``). The return value of
        ``object_hook`` will be used instead of the ``dict``. This feature
        can be used to implement custom decoders (e.g. JSON-RPC class hinting).
    
        ``object_pairs_hook`` is an optional function that will be called with the
        result of any object literal decoded with an ordered list of pairs.  The
        return value of ``object_pairs_hook`` will be used instead of the ``dict``.
        This feature can be used to implement custom decoders.  If ``object_hook``
        is also defined, the ``object_pairs_hook`` takes priority.
    
        ``parse_float``, if specified, will be called with the string
        of every JSON float to be decoded. By default this is equivalent to
        float(num_str). This can be used to use another datatype or parser
        for JSON floats (e.g. decimal.Decimal).
    
        ``parse_int``, if specified, will be called with the string
        of every JSON int to be decoded. By default this is equivalent to
        int(num_str). This can be used to use another datatype or parser
        for JSON integers (e.g. float).
    
        ``parse_constant``, if specified, will be called with one of the
        following strings: -Infinity, Infinity, NaN.
        This can be used to raise an exception if invalid JSON numbers
        are encountered.
    
        To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
        kwarg; otherwise ``JSONDecoder`` is used.
    
        The ``encoding`` argument is ignored and deprecated since Python 3.1.
        """
        if isinstance(s, str):
            if s.startswith('\ufeff'):
                raise JSONDecodeError("Unexpected UTF-8 BOM (decode using utf-8-sig)",
                                      s, 0)
        else:
            if not isinstance(s, (bytes, bytearray)):
                raise TypeError(f'the JSON object must be str, bytes or bytearray, '
                                f'not {s.__class__.__name__}')
            s = s.decode(detect_encoding(s), 'surrogatepass')
    
        if "encoding" in kw:
            import warnings
            warnings.warn(
                "'encoding' is ignored and deprecated. It will be removed in Python 3.9",
                DeprecationWarning,
                stacklevel=2
            )
            del kw['encoding']
    
        if (cls is None and object_hook is None and
                parse_int is None and parse_float is None and
                parse_constant is None and object_pairs_hook is None and not kw):
            return _default_decoder.decode(s)
        if cls is None:
            cls = JSONDecoder
        if object_hook is not None:
            kw['object_hook'] = object_hook
        if object_pairs_hook is not None:
            kw['object_pairs_hook'] = object_pairs_hook
        if parse_float is not None:
            kw['parse_float'] = parse_float
        if parse_int is not None:
            kw['parse_int'] = parse_int
        if parse_constant is not None:
            kw['parse_constant'] = parse_constant
>       return cls(**kw).decode(s)

../../anaconda3/envs/taxcalc-dev/lib/python3.8/json/__init__.py:370: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <json.decoder.JSONDecoder object at 0x1450f44c0>
s = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.d...e.clientHeight||b.clientHeight;url+="&w="+x+"&h="+y;}window.location.replace(url);</script></head><body></body></html>'
_w = <built-in method match of re.Pattern object at 0x10dada4b0>

    def decode(self, s, _w=WHITESPACE.match):
        """Return the Python representation of ``s`` (a ``str`` instance
        containing a JSON document).
    
        """
>       obj, end = self.raw_decode(s, idx=_w(s, 0).end())

../../anaconda3/envs/taxcalc-dev/lib/python3.8/json/decoder.py:337: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <json.decoder.JSONDecoder object at 0x1450f44c0>
s = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.d...e.clientHeight||b.clientHeight;url+="&w="+x+"&h="+y;}window.location.replace(url);</script></head><body></body></html>'
idx = 0

    def raw_decode(self, s, idx=0):
        """Decode a JSON document from ``s`` (a ``str`` beginning with
        a JSON document) and return a 2-tuple of the Python
        representation and the index in ``s`` where the document ended.
    
        This can be used to decode a JSON document from a string that may
        have extraneous data at the end.
    
        """
        try:
            obj, end = self.scan_once(s, idx)
        except StopIteration as err:
>           raise JSONDecodeError("Expecting value", s, err.value) from None
E           json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

../../anaconda3/envs/taxcalc-dev/lib/python3.8/json/decoder.py:355: JSONDecodeError

The above exception was the direct cause of the following exception:

tests_path = '/Users/matthewjensen/Projects/Tax-Calculator/taxcalc/tests'

    def test_bad_json_names(tests_path):
        """
        Test that ValueError raised with assump or reform do not end in '.json'
        """
        csvname = os.path.join(tests_path, '..', 'growfactors.csv')
        with pytest.raises(ValueError):
            Calculator.read_json_param_objects(csvname, None)
        with pytest.raises(FileNotFoundError):
>           Calculator.read_json_param_objects('http://name.json.html', None)

taxcalc/tests/test_calculator.py:398: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
taxcalc/calculator.py:1102: in read_json_param_objects
    param_dict['policy'] = Policy.read_json_reform(reform)
taxcalc/policy.py:112: in read_json_reform
    return Parameters._read_json_revision(obj, 'policy')
taxcalc/parameters.py:749: in _read_json_revision
    full_dict = pt.read_json(obj)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

params_or_path = 'http://name.json.html', storage_options = None

    def read_json(
        params_or_path: FileDictStringLike,
        storage_options: Optional[Dict[str, Any]] = None,
    ):
        """
        Read JSON data of the form:
        - Dict.
        - JSON string.
        - Local file path.
        - Any URL readable by fsspec. For example:
          - s3: s3://paramtools-test/defaults.json
          - gcs: gs://paramtools-dev/defaults.json
          - http: https://somedomain.com/defaults.json
          - github: github://PSLmodels:ParamTools@master/paramtools/tests/defaults.json
    
        """
        res = _read(params_or_path, storage_options)
        if isinstance(res, str):
            try:
                res = remove_comments(res)
                return json.loads(res, object_pairs_hook=OrderedDict)
            except json.JSONDecodeError as je:
                if len(res) > 100:
                    res = res[:100] + "..." + res[-10:]
>               raise ValueError(f"Unable to decode JSON string: {res}") from je
E               ValueError: Unable to decode JSON string: <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtm...dy></html>

../../anaconda3/envs/taxcalc-dev/lib/python3.8/site-packages/paramtools/utils.py:113: ValueError
=================================================================================== warnings summary ===================================================================================
../../anaconda3/envs/taxcalc-dev/lib/python3.8/site-packages/numba/core/types/__init__.py:108
  /Users/matthewjensen/anaconda3/envs/taxcalc-dev/lib/python3.8/site-packages/numba/core/types/__init__.py:108: DeprecationWarning: `np.long` is a deprecated alias for `np.compat.long`. To silence this warning, use `np.compat.long` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `int` for which `np.compat.long` is itself an alias. Doing this will not modify any behaviour and is safe. When replacing `np.long`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    long_ = _make_signed(np.long)

../../anaconda3/envs/taxcalc-dev/lib/python3.8/site-packages/numba/core/types/__init__.py:109
  /Users/matthewjensen/anaconda3/envs/taxcalc-dev/lib/python3.8/site-packages/numba/core/types/__init__.py:109: DeprecationWarning: `np.long` is a deprecated alias for `np.compat.long`. To silence this warning, use `np.compat.long` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `int` for which `np.compat.long` is itself an alias. Doing this will not modify any behaviour and is safe. When replacing `np.long`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    ulong = _make_unsigned(np.long)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================================================== short test summary info ================================================================================
FAILED taxcalc/tests/test_calculator.py::test_bad_json_names - ValueError: Unable to decode JSON string: <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w...
========================================================== 1 failed, 304 passed, 44 skipped, 2 warnings in 3470.10s (0:57:50) ==========================================================
(taxcalc-dev) Matthews-MBP:tax-calculator matthewjensen$ conda list
# packages in environment at /Users/matthewjensen/anaconda3/envs/taxcalc-dev:
#
# Name                    Version                   Build  Channel
aiohttp                   3.7.4            py38h96a0964_0    conda-forge
alabaster                 0.7.12                   pypi_0    pypi
apipkg                    1.5                        py_0    conda-forge
appnope                   0.1.2                    pypi_0    pypi
argon2-cffi               20.1.0                   pypi_0    pypi
astroid                   2.5              py38h50d1736_1    conda-forge
async-generator           1.10                     pypi_0    pypi
async-timeout             3.0.1                   py_1000    conda-forge
attrs                     20.3.0             pyhd3deb0d_0    conda-forge
babel                     2.9.0                    pypi_0    pypi
backcall                  0.2.0                    pypi_0    pypi
beautifulsoup4            4.9.3                    pypi_0    pypi
bleach                    3.3.0                    pypi_0    pypi
bokeh                     2.2.3            py38h50d1736_0    conda-forge
brotlipy                  0.7.0           py38h5406a74_1001    conda-forge
ca-certificates           2020.12.5            h033912b_0    conda-forge
certifi                   2020.12.5        py38h50d1736_1    conda-forge
cffi                      1.14.5           py38ha97d567_0    conda-forge
chardet                   4.0.0            py38h50d1736_1    conda-forge
click                     7.1.2                    pypi_0    pypi
colorama                  0.4.4                    pypi_0    pypi
coverage                  5.4              py38h5406a74_0    conda-forge
cryptography              3.4.4            py38h43df06b_0    conda-forge
decorator                 4.4.2                    pypi_0    pypi
defusedxml                0.6.0                    pypi_0    pypi
docutils                  0.16                     pypi_0    pypi
entrypoints               0.3                      pypi_0    pypi
execnet                   1.8.0              pyh44b312d_0    conda-forge
freetype                  2.10.4               h4cff582_1    conda-forge
fsspec                    0.8.7              pyhd8ed1ab_0    conda-forge
gitdb                     4.0.5                    pypi_0    pypi
gitpython                 3.1.13                   pypi_0    pypi
idna                      2.10               pyh9f0ad1d_0    conda-forge
imagesize                 1.2.0                    pypi_0    pypi
importlib-metadata        3.7.0                    pypi_0    pypi
iniconfig                 1.1.1              pyh9f0ad1d_0    conda-forge
ipykernel                 5.5.0                    pypi_0    pypi
ipython                   7.21.0                   pypi_0    pypi
ipython-genutils          0.2.0                    pypi_0    pypi
ipywidgets                7.6.3                    pypi_0    pypi
isort                     5.7.0              pyhd8ed1ab_0    conda-forge
jedi                      0.18.0                   pypi_0    pypi
jinja2                    2.11.3             pyh44b312d_0    conda-forge
jpeg                      9d                   hbcb3906_0    conda-forge
jsonschema                3.2.0                    pypi_0    pypi
jupyter-book              0.10.0                   pypi_0    pypi
jupyter-cache             0.4.2                    pypi_0    pypi
jupyter-client            6.1.11                   pypi_0    pypi
jupyter-core              4.7.1                    pypi_0    pypi
jupyter-sphinx            0.3.1                    pypi_0    pypi
jupyterlab-widgets        1.0.0                    pypi_0    pypi
jupytext                  1.8.2                    pypi_0    pypi
latexcodec                2.0.1                    pypi_0    pypi
lazy-object-proxy         1.5.2            py38h5406a74_1    conda-forge
lcms2                     2.12                 h577c468_0    conda-forge
libblas                   3.9.0                8_openblas    conda-forge
libcblas                  3.9.0                8_openblas    conda-forge
libcxx                    11.0.1               habf9029_0    conda-forge
libffi                    3.3                  h046ec9c_2    conda-forge
libgfortran               5.0.0           9_3_0_h6c81a4c_19    conda-forge
libgfortran5              9.3.0               h6c81a4c_19    conda-forge
liblapack                 3.9.0                8_openblas    conda-forge
libllvm10                 10.0.1               h009f743_3    conda-forge
libopenblas               0.3.12          openmp_h54245bb_1    conda-forge
libpng                    1.6.37               h7cec526_2    conda-forge
libtiff                   4.2.0                h355d032_0    conda-forge
libwebp-base              1.2.0                hbcf498f_0    conda-forge
linkify-it-py             1.0.1                    pypi_0    pypi
llvm-openmp               11.0.1               h7c73e74_0    conda-forge
llvmlite                  0.35.0           py38hc583f44_1    conda-forge
lz4-c                     1.9.3                h046ec9c_0    conda-forge
markdown-it-py            0.6.2                    pypi_0    pypi
markupsafe                1.1.1            py38h5406a74_3    conda-forge
marshmallow               3.10.0             pyhd8ed1ab_0    conda-forge
mccabe                    0.6.1                      py_1    conda-forge
mdit-py-plugins           0.2.5                    pypi_0    pypi
mistune                   0.8.4                    pypi_0    pypi
more-itertools            8.7.0              pyhd8ed1ab_0    conda-forge
multidict                 5.1.0            py38h5406a74_1    conda-forge
myst-nb                   0.11.1                   pypi_0    pypi
myst-parser               0.13.5                   pypi_0    pypi
nbclient                  0.5.3                    pypi_0    pypi
nbconvert                 5.6.1                    pypi_0    pypi
nbdime                    2.1.0                    pypi_0    pypi
nbformat                  5.1.2                    pypi_0    pypi
ncurses                   6.2                  h2e338ed_4    conda-forge
nest-asyncio              1.5.1                    pypi_0    pypi
nested-lookup             0.2.22                   pypi_0    pypi
notebook                  6.2.0                    pypi_0    pypi
numba                     0.52.0           py38he9f00de_0    conda-forge
numpy                     1.20.1           py38h64deac9_0    conda-forge
olefile                   0.46               pyh9f0ad1d_1    conda-forge
openssl                   1.1.1j               hbcf498f_0    conda-forge
packaging                 20.9               pyh44b312d_0    conda-forge
pandas                    1.2.2            py38hb77cc89_0    conda-forge
pandocfilters             1.4.3                    pypi_0    pypi
paramtools                0.18.0             pyh44b312d_0    conda-forge
parso                     0.8.1                    pypi_0    pypi
pep8                      1.7.1                      py_0    conda-forge
pexpect                   4.8.0                    pypi_0    pypi
pickleshare               0.7.5                    pypi_0    pypi
pillow                    8.1.0            py38h4c06724_2    conda-forge
pip                       21.0.1             pyhd8ed1ab_0    conda-forge
pluggy                    0.13.1           py38h50d1736_4    conda-forge
prometheus-client         0.9.0                    pypi_0    pypi
prompt-toolkit            3.0.16                   pypi_0    pypi
ptyprocess                0.7.0                    pypi_0    pypi
py                        1.10.0             pyhd3deb0d_0    conda-forge
pybtex                    0.24.0                   pypi_0    pypi
pybtex-docutils           1.0.0                    pypi_0    pypi
pycodestyle               2.6.0              pyh9f0ad1d_0    conda-forge
pycparser                 2.20               pyh9f0ad1d_2    conda-forge
pydata-sphinx-theme       0.4.3                    pypi_0    pypi
pygments                  2.8.0                    pypi_0    pypi
pylint                    2.6.0            py38h50d1736_1    conda-forge
pyopenssl                 20.0.1             pyhd8ed1ab_0    conda-forge
pyparsing                 2.4.7              pyh9f0ad1d_0    conda-forge
pyrsistent                0.17.3                   pypi_0    pypi
pysocks                   1.7.1            py38h50d1736_3    conda-forge
pytest                    6.2.2            py38h50d1736_0    conda-forge
pytest-cache              1.0                        py_2    conda-forge
pytest-forked             1.3.0              pyhd3deb0d_0    conda-forge
pytest-pep8               1.0.6                      py_2    conda-forge
pytest-xdist              2.2.1              pyhd8ed1ab_0    conda-forge
python                    3.8.8           h4e93d89_0_cpython    conda-forge
python-dateutil           2.8.1                      py_0    conda-forge
python_abi                3.8                      1_cp38    conda-forge
pytz                      2021.1             pyhd8ed1ab_0    conda-forge
pyyaml                    5.4.1            py38h5406a74_0    conda-forge
pyzmq                     22.0.3                   pypi_0    pypi
readline                  8.0                  h0678c8f_2    conda-forge
requests                  2.25.1             pyhd3deb0d_0    conda-forge
send2trash                1.5.0                    pypi_0    pypi
setuptools                49.6.0           py38h50d1736_3    conda-forge
six                       1.15.0             pyh9f0ad1d_0    conda-forge
smmap                     3.0.5                    pypi_0    pypi
snowballstemmer           2.1.0                    pypi_0    pypi
sortedcontainers          2.3.0              pyhd8ed1ab_0    conda-forge
soupsieve                 2.2                      pypi_0    pypi
sphinx                    3.5.1                    pypi_0    pypi
sphinx-book-theme         0.0.39                   pypi_0    pypi
sphinx-comments           0.0.3                    pypi_0    pypi
sphinx-copybutton         0.3.1                    pypi_0    pypi
sphinx-panels             0.5.2                    pypi_0    pypi
sphinx-thebe              0.0.8                    pypi_0    pypi
sphinx-togglebutton       0.2.3                    pypi_0    pypi
sphinxcontrib-applehelp   1.0.2                    pypi_0    pypi
sphinxcontrib-bibtex      2.1.4                    pypi_0    pypi
sphinxcontrib-devhelp     1.0.2                    pypi_0    pypi
sphinxcontrib-htmlhelp    1.0.3                    pypi_0    pypi
sphinxcontrib-jsmath      1.0.1                    pypi_0    pypi
sphinxcontrib-qthelp      1.0.3                    pypi_0    pypi
sphinxcontrib-serializinghtml 1.1.4                    pypi_0    pypi
sqlalchemy                1.3.23                   pypi_0    pypi
sqlite                    3.34.0               h17101e1_0    conda-forge
terminado                 0.9.2                    pypi_0    pypi
testpath                  0.4.4                    pypi_0    pypi
tk                        8.6.10               h0419947_1    conda-forge
toml                      0.10.2             pyhd8ed1ab_0    conda-forge
tornado                   6.1              py38h5406a74_1    conda-forge
traitlets                 5.0.5                    pypi_0    pypi
typing-extensions         3.7.4.3                       0    conda-forge
typing_extensions         3.7.4.3                    py_0    conda-forge
uc-micro-py               1.0.1                    pypi_0    pypi
urllib3                   1.26.3             pyhd8ed1ab_0    conda-forge
wcwidth                   0.2.5                    pypi_0    pypi
webencodings              0.5.1                    pypi_0    pypi
wheel                     0.36.2             pyhd3deb0d_0    conda-forge
widgetsnbextension        3.5.1                    pypi_0    pypi
wrapt                     1.12.1           py38h5406a74_3    conda-forge
xz                        5.2.5                haf1e3a3_1    conda-forge
yaml                      0.2.5                haf1e3a3_0    conda-forge
yarl                      1.6.3            py38h5406a74_1    conda-forge
zipp                      3.4.0                    pypi_0    pypi
zlib                      1.2.11            h7795811_1010    conda-forge
zstd                      1.4.8                hf387650_1    conda-forge
(taxcalc-dev) Matthews-MBP:tax-calculator matthewjensen$ 
```