### PR TITLE
Add testing for Mac OS in GH Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
 
     steps:


### PR DESCRIPTION
This PR adds the os `macos-latest` to the testing suite in GH actions. I figure we can make testing fully robust by including all OSs.