### PR TITLE
Change installation location to conda-forge in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ You can install it with [Anaconda](https://www.anaconda.com/products/individual)
 via:
 
 ```
-conda install -c pslmodels taxcalc
+conda install -c conda-forge taxcalc
 ```
 
 When using
@@ -56,7 +56,7 @@ The cross-model validation work with NBER's TAXSIM-27 model is described
 If you are already using Tax-Calculator, upgrade using the following command:
 
 ```
-conda update -c PSLmodels taxcalc
+conda update -c conda-forge taxcalc
 ```
 
 If you're a new user, read {doc}`usage/starting`.


### PR DESCRIPTION
Changes installation instructions to `conda install -c conda-forge taxcalc` in the docs.