### PR TITLE
Use 3.8 to build JB

### DIFF
--- a/.github/workflows/check_jupyterbook.yml
+++ b/.github/workflows/check_jupyterbook.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           activate-environment: taxcalc-dev
           environment-file: environment.yml
-          python-version: 3.9
+          python-version: 3.8
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           activate-environment: taxcalc-dev
           environment-file: environment.yml
-          python-version: 3.9
+          python-version: 3.8
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book


### PR DESCRIPTION
This PR specifies that Python version 3.8 be used to build the Jupyter Book. This fixes an issue noted by @rickecon in PR #2573, where Behavioral-Responses package is incompatible with the environment used to build the Jupyter Book documentation.