### PR TITLE
Fix testing benchmark GH action

### DIFF
--- a/.github/workflows/build_new_test_benchmark.yml
+++ b/.github/workflows/build_new_test_benchmark.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-        with:
-          persist-credentials: false
 
       - name: Setup Miniconda using Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Attempts to fix GH action to build testing benchmark file. @MattHJensen I believe `persist_credentials: false` must be turned off so that the `github-actions` bot can be authenticated for making commits.