### PR TITLE
[Ready] Remove Python 3.6 from tests in GH Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build Package and Test Source Code [Python 3.6, 3.7, 3.8, 3.9]
+name: Build Package and Test Source Code [Python 3.7, 3.8, 3.9]
 
 on: [push, pull_request]
 
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,12 +35,12 @@ jobs:
         working-directory: ./
         run: |
           pytest -m 'not requires_pufcsv and not pre_release and not local' --cov=./ --cov-report=xml
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v1
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-      #     file: ./coverage.xml
-      #     flags: unittests
-      #     name: codecov-umbrella
-      #     fail_ci_if_error: true
-      #     verbose: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+          verbose: true

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - requests
 - aiohttp
 - numba
+- "fsspec<=0.8.7"
 - pytest
 - pytest-pep8
 - pytest-xdist

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -31,7 +31,7 @@ def test_for_consistency(tests_path):
     and conda.recipe/meta.yaml requirements.
     """
     dev_pkgs = set([
-        'fsspec<=0.8.7'
+        'fsspec<=0.8.7',
         'pytest',
         'pytest-pep8',
         'pytest-xdist',

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -31,6 +31,7 @@ def test_for_consistency(tests_path):
     and conda.recipe/meta.yaml requirements.
     """
     dev_pkgs = set([
+        'fsspec<=0.8.7'
         'pytest',
         'pytest-pep8',
         'pytest-xdist',


### PR DESCRIPTION
This PR removes Python 3.6 from the GH action's test suite. Addresses #2582.

cc @MattHJensen 