### PR TITLE
Fix bugs in profiling suite

### DIFF
--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -167,5 +167,4 @@ def pytest_sessionfinish(session):
 
     # Save new test stats to disk including time diff
     new_stats_df['time_diff'] = merge_df['time_diff'].values
-    print(new_stats_df['time_diff'])
     new_stats_df.to_csv(os.path.join(tests_path, 'test_stats_current.csv'))


### PR DESCRIPTION
This PR fixes in a bug in the profiling suite noticed in #2572. The profiling suite will no longer throw an error if new tests are introduced.

Thanks @jdebacker @amshoulders 
cc @MattHJensen