### PR TITLE
Prepares 3.2.1

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -7,7 +7,7 @@ for a complete commit history.
 2021-08-02 Release 3.2.1
 ------------------------
 (last merged pull request is
-[#2604](https://github.com/PSLmodels/Tax-Calculator/pull/2604))
+[#2615](https://github.com/PSLmodels/Tax-Calculator/pull/2614))
 
 **This is bug-fix release.**
 

--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -4,10 +4,10 @@ Go [here](https://github.com/PSLmodels/Tax-Calculator/pulls?q=is%3Apr+is%3Aclose
 for a complete commit history.
 
 
-2021-08-02 Release 3.2.1
+2021-08-06 Release 3.2.1
 ------------------------
 (last merged pull request is
-[#2615](https://github.com/PSLmodels/Tax-Calculator/pull/2614))
+[#2615](https://github.com/PSLmodels/Tax-Calculator/pull/2615))
 
 **This is bug-fix release.**
 

--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -4,6 +4,21 @@ Go [here](https://github.com/PSLmodels/Tax-Calculator/pulls?q=is%3Apr+is%3Aclose
 for a complete commit history.
 
 
+2021-08-02 Release 3.2.1
+------------------------
+(last merged pull request is
+[#2604](https://github.com/PSLmodels/Tax-Calculator/pull/2604))
+
+**This is bug-fix release.**
+
+**API Changes**
+
+**New Features**
+
+**Bug Fixes**
+Correct an error in the value of the `CTC_new_c_under6_bonus` for the year 2021. [[#2609](https://github.com/PSLmodels/Tax-Calculator/pull/2609) by Jason DeBacker]
+
+
 2021-07-17 Release 3.2.0
 ------------------------
 (last merged pull request is

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ The cross-model validation work with NBER's TAXSIM-27 model is described
 
 ## Latest release
 
-{doc}`3.2.0 (2021-07-17) <about/releases>`
+{doc}`3.2.1 (2021-08-02) <about/releases>`
 
 If you are already using Tax-Calculator, upgrade using the following command:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ The cross-model validation work with NBER's TAXSIM-27 model is described
 
 ## Latest release
 
-{doc}`3.2.1 (2021-08-02) <about/releases>`
+{doc}`3.2.1 (2021-08-06) <about/releases>`
 
 If you are already using Tax-Calculator, upgrade using the following command:
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 with open('README.md') as f:
     longdesc = f.read()
 
-version = '3.2.0'
+version = '3.2.1'
 
 config = {
     'description': 'Tax Calculator',

--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: taxcalc
-Version: 3.2.0
+Version: 3.2.1
 Summary: taxcalc
 Home-page: https://github.com/PSLmodels/Tax-Calculator
 Author: UNKNOWN

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -14,4 +14,4 @@ from taxcalc.taxcalcio import *
 from taxcalc.utils import *
 from taxcalc.cli import *
 
-__version__ = '3.2.0'
+__version__ = '3.2.1'


### PR DESCRIPTION
This PR preparers Tax-Calculator 3.2.1.  This release fixes an error in the value of the `CTC_new_c_under6_bonus` parameter in 2021.

- [x] Update version number in `RELEASES.md`
- [x] Update version number in `index.md`
- [x] Update version number in `setup.py`
- [x] Update version number in `taxcalc/__init__.py`
- [x] `make tctest-jit` pass locally
- [x] `make pytest-all` passes locally
- [x] `taxcalc/validation/tests.sh` pass locally