### PR TITLE
Reorder use cases

### DIFF
--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -1,102 +1,242 @@
 Recorded use cases
 ==================
 
-\[1\] Kevin Hassett. On the Dynamic Scoring of Fiscal Policy. July 2015.
+\[69\] Max Gehnis. California's basic income bill still needs work.
+April 2021. URL:
+<https://blog.ubicenter.org/20210403/california-ab65-calubi.html>
+(visited on 2021-04-06).
+
+\[68\] Alex Brill, Kyle Pomerleau, and Grant Seiter. How will the
+American Rescue Plan impact your 2021 tax liability? March 2021.
+Section: Economics. URL:
+<https://www.aei.org/economics/how-will-the-american-rescue-plan-impact-your-2021-tax-liability/>
+(visited on 2021-04-05).
+
+\[67\] Alex Brill. The American Rescue Plan's likely cost is way more
+than \$1.9 trillion. March 2021. URL:
+<https://www.aei.org/economics/the-american-rescue-plans-likely-cost-is-way-more-than-1-9-trillion/>
+(visited on 2021-03-05).
+
+\[66\] Alex Brill, Kyle Pomerleau, and Grant Seiter. Pick your Child Tax
+Credit. March 2021. Section: Economics. URL:
+<https://www.aei.org/economics/pick-your-child-tax-credit/> (visited on
+2021-04-05).
+
+\[65\] Alex Brill, Kyle Pomerleau, and Grant Seiter. The tax benefits of
+parenthood: A history and analysis of current proposals. February 2021.
+Section: Economics. URL:
+<https://www.aei.org/research-products/report/the-tax-benefits-of-parenthood-a-history-and-analysis-of-current-proposals/>
+(visited on 2021-02-25).
+
+\[64\] Robert Orr and Samuel Hammond. Analysis of the Romney Child
+Allowance. February 2021. URL:
+<https://www.niskanencenter.org/wp-content/uploads/2021/02/Analysis-of-the-Romney-Child-Allowance_final.pdf>
+(visited on 2021-02-12).
+
+\[63\] Angela Rachidi. Reducing the marriage penalty for low-income
+families. January 2021. URL:
+<https://www.aei.org/poverty-studies/reducing-the-marriage-tax-penalty-for-low-income-families/>.
+
+\[62\] Kyle Pomerleau and Peter Metz. How would your taxes change under
+Joe Biden\'s tax plan? November 2020. URL:
+<https://compute.studio/AEIEconomics/Tax-Cruncher-Biden/>.
+
+\[61\] Kyle Pomerleau and Peter Metz. How would Joe Biden's tax
+proposals impact your tax liability? October 2020. Section: Economics.
 URL:
-<https://www.aei.org/press/on-the-dynamic-scoring-of-fiscal-policy/>
+<https://www.aei.org/economics/how-would-joe-bidens-tax-proposals-impact-your-tax-liability/>.
+
+\[60\] Timothy Fitzgerald, Kevin Hassett, Cody Kallen, and Casey
+Mulligan. An Analysis of Vice President Biden's Economic Agenda: The
+Long Run Impacts of Its Regulation, Taxes, and Spending\*. October 2020.
+URL:
+<https://www.hoover.org/research/analysis-vice-president-bidens-economic-agenda-long-run-impacts>.
+
+\[59\] Kyle Pomerleau. An analysis of Joe Biden's tax proposals, October
+2020 update. October 2020. Section: Economics. URL:
+<https://www.aei.org/research-products/report/an-analysis-of-joe-bidens-tax-proposals-october-2020-update/>.
+
+\[58\] Richard Rubin. How Biden's Tax Plan Would Affect Five American
+Households. Wall Street Journal, September 2020. URL:
+<https://www.wsj.com/articles/how-bidens-tax-plan-might-affect-five-american-households-11599739200>.
+
+\[57\] Kyle Pomerleau. The tax burden on business investment under Joe
+Biden's tax proposals. September 2020. Section: Economics. URL:
+<https://www.aei.org/research-products/report/the-tax-burden-on-business-investment-under-joe-bidens-tax-proposals/>
+(visited on 2020-11-02).
+
+\[56\] Matt Jensen and Peter Metz. Effective tax rates on capital under
+current law and Joe Biden\'s tax proposal. September 2020. URL:
+<https://compute.studio/AEIEconomics/ccc-biden/> (visited on
+2020-11-03).
+
+\[55\] Max Ghenis and Nate Silver. Poverty and inequality effects of new
+unemployment benefits, payroll tax cuts, and universal payments. July
+1.    URL: <https://covid.ubicenter.org/fpuc.html> (visited on
+2020-11-02).
+
+\[54\] Kyle Pomerleau. An analysis of Joe Biden\'s tax proposals. June
+1.    Section: Economics. URL:
+<https://www.aei.org/research-products/report/an-analysis-of-joe-bidens-tax-proposals/>
+(visited on 2020-11-02).
+
+\[53\] Kyle Pomerleau. Eligible dependents in the CARES Act and HEROES
+Act economic relief payments. May 2020. Section: Economics. URL:
+<https://www.aei.org/economics/eligible-dependents-in-the-cares-act-and-heroes-act-economic-relief-payments/>
+(visited on 2020-11-02).
+
+\[52\] Kyle Pomerleau. Kyle Pomerleau on Twitter. May 2020. URL:
+<https://twitter.com/kpomerleau/status/1258497005598453761> (visited on
+2020-11-03).
+
+\[51\] Don Boyd. A New Synthetic Data Set for Tax Policy Analysis.
+Quantitative Notes, 2:7, May 2020. URL:
+<https://www.openrg.com/reports/SynData_QN.pdf>.
+
+\[50\] Kyle Pomerleau. The CARES Act: Who will get a rebate and how
+much? March 2020. Section: Economics. URL:
+<https://www.aei.org/economics/the-care-act-who-will-get-a-rebate-and-how-much/>
+(visited on 2020-11-02).
+
+\[49\] Ernie Tedeschi. The Distribution of Household Rebate Ideas So
+Far. March 2020. URL:
+<https://medium.com/@ernietedeschi/the-distribution-of-household-rebate-ideas-so-far-2b71a8a19914>
+(visited on 2020-11-03).
+
+\[48\] Ernie Tedeschi. Updated Distribution of Household Rebate Ideas So
+Far. March 2020. URL:
+<https://medium.com/@ernietedeschi/updated-distribution-of-household-rebate-ideas-so-far-f46360034f9d>
+(visited on 2020-11-03).
+
+\[47\] Committee for a Responsible Federal Budget. Choices for Financing
+Medicare for All. Technical Report, Committee for a Responsible Federal
+Budget, March 2020. URL:
+<http://www.crfb.org/papers/choices-financing-medicare-all> (visited on
+2020-06-24).
+
+\[46\] Kyle Pomerleau. Kyle Pomerleau on Twitter. March 2020. URL:
+<https://twitter.com/kpomerleau/status/1237439229627699200> (visited on
+2020-11-03).
+
+\[45\] Matt Jensen, Peter Metz, and Jason DeBacker. A static simulation
+of several personal income and payroll tax provisions from the Biden
+2020 reform. by Peter-Metz. 2020. URL:
+<https://compute.studio/PSLmodels/Tax-Brain/46307/> (visited on
+2020-11-03).
+
+\[44\] Matt Jensen. Transparency for Congress\'s Scorekeepers. National
+Affairs, 2020. URL:
+<https://www.nationalaffairs.com/publications/detail/transparency-for-congresss-scorekeepers>
 (visited on 2020-06-24).
 
-\[2\] Kevin Hassett. Reaching America\'s potential: Delivering growth
-and opportunity for all Americans. February 2016. URL:
-<https://www.aei.org/research-products/speech/statement-before-the-house-ways-and-means-committee/>
+\[43\] Jaeger Nelson and Kerk Phillips. Macroeconomic Effects of
+Reducing OASI Benefits: A Comparison of Seven Overlapping-Generations
+Models. National Tax Journal, 70(4):671--692, December 2019. URL:
+<http://www.ntanet.org/NTJ/72/4/ntj-v72n04p671-692-Macroeconomic-Effects-of-Reducing-OASI-Benefits.html>
+(visited on 2020-06-24), doi:10.17310/ntj.2019.4.02.
+
+\[42\] Aparna Mathur. Rethinking the Green New Deal: Using Climate
+Policy to Address Inequality. National Tax Journal, 70(4):693--722,
+December 2019. URL:
+<http://www.ntanet.org/NTJ/72/4/ntj-v72n04p693-722-Rehinking-the-Green-New-Deal.html>
+(visited on 2020-06-24), doi:10.17310/ntj.2019.4.03.
+
+\[41\] Alan D. Viard and Sita Nataraj Slavov. The Wrong Way to Make
+Social Security and Medicare More Progressive. Tax Notes, September
+1.    URL:
+<https://www.taxnotes.com/tax-notes-federal/social-welfare-taxation/wrong-way-make-social-security-and-medicare-more-progressive/2019/09/16/29wpk>
 (visited on 2020-06-24).
 
-\[3\] Alex Brill. Understanding middle-class tax cuts. Technical Report,
-AEI, April 2016. URL:
-<https://www.aei.org/research-products/report/understanding-middle-class-tax-cuts/>
+\[40\] Lily L. Batchelder and David Kamin. Taxing the Rich: Issues and
+Options. SSRN Scholarly Paper ID 3452274, Social Science Research
+Network, Rochester, NY, September 2019.
+
+\[39\] Max Ghenis. Distributional analysis of Andrew Yang's Freedom
+Dividend. June 2019. URL:
+<https://medium.com/ubicenter/distributional-analysis-of-andrew-yangs-freedom-dividend-d8dab818bf1b>
 (visited on 2020-06-24).
 
-\[4\] Jim Tankersley. The search for the best middle-class tax cut.
-Washington Post, April 2016. URL:
-<https://www.washingtonpost.com/news/wonk/wp/2016/04/14/the-search-for-the-best-middle-class-tax-cut/>
+\[38\] Alan D. Viard. An Economic Analysis of the TCJA's Larger Standard
+Deduction. Tax Notes, April 2019. URL:
+<https://www.aei.org/wp-content/uploads/2019/04/On-the-Margin-April-1-2019.pdf>
 (visited on 2020-06-24).
 
-\[5\] Aparna Mathur and Adele Hunter. Leaving Childless Taxpayers Behind
-in the Tax Code \\textbar AEI. Tax Notes, July 2016. Library Catalog:
-[www.aei.org](http://www.aei.org) Section: Public Economics. URL:
-<https://www.aei.org/articles/leaving-childless-taxpayers-behind-in-the-tax-code/>
+\[37\] Aparna Mathur. The Tax Cuts and Jobs Act: Anything but a simple
+tax reform \\textbar AEI. Bloomberg Tax, March 2019. URL:
+<https://www.aei.org/articles/the-tax-cuts-and-jobs-act-anything-but-a-simple-tax-reform/>
 (visited on 2020-06-24).
 
-\[6\] Richard Rubin. Why It's So Hard to Get Rid of Tax 'Loopholes'.
-August 2016. URL:
-<https://web.archive.org/web/20160819134156/http://blogs.wsj.com/economics/2016/08/18/why-its-so-hard-to-get-rid-of-tax-loopholes/>
+\[36\] Ernie Tedeschi. An Analysis of the Earned Basic Income Tax
+Credit. March 2019. URL:
+<https://drive.google.com/file/d/1Ko0kQXP7FEdzdvGJq4N7MmRbemFNH8Xp/view?mkt_tok=eyJpIjoiWVRRMFpqTXhOVGcwTkRBNSIsInQiOiJzNk5CWkpqOUlzeGc4Z0ZRUXYwSnRXT0ZZSGVwczNwa3A3UVwvUWdKaEVuc2E2TE91NUVUcjVEU1doMEdsSnpcL1BIVzE4U2NzeGZFOENBWmhiUlwvbDhUSUxsQVJ4cXJJTDJYcExsdElUV0xkMFFaRzJoMlRtTGNOZWM3RHZHeDNBUSJ9&usp=embed_facebook>
 (visited on 2020-06-24).
 
-\[7\] Alex Brill. Tax reform: Ryan-Brady plan is a better way. Technical
-Report, AEI, October 2016. URL:
-<https://www.aei.org/research-products/report/tax-reform-ryan-brady-plan-is-a-better-way/>
+\[35\] Council of Economic Advisors. Economic Report of the President.
+Technical Report PR 45.9, Council of Economic Advisors, March 2019. URL:
+<https://www.govinfo.gov/content/pkg/ERP-2019/pdf/ERP-2019.pdf>.
+
+\[34\] Aparna Mathur and Cody Kallen. Estimating the distributional
+implications of the Tax Cuts and Jobs Act. Technical Report, AEI,
+February 2019. URL:
+<https://www.aei.org/research-products/working-paper/estimating-the-distributional-implications-of-the-tax-cuts-and-jobs-act/>
 (visited on 2020-06-24).
 
-\[8\] Dylan Matthews. House Republicans are proposing a big corporate
-tax cut that Walmart hates. Vox, December 2016. URL:
-<https://www.vox.com/2016/12/25/14069822/corporate-tax-border-adjustability>
+\[33\] Jason DeBacker, Richard W. Evans, and Kerk L. Phillips.
+Integrating Microsimulation Models of Tax Policy into a DGE
+Macroeconomic Model. Public Finance Review, 47(2):207--275, February
+1.    URL: <https://doi.org/10.1177/1091142118816744> (visited on
+2020-06-24), doi:10.1177/1091142118816744.
+
+\[32\] Aparna Mathur. A 70 percent tax rate on the rich may be smart
+politics, but is not smart economics \\textbar AEI. Bloomberg Tax,
+January 2019. URL:
+<https://www.aei.org/articles/a-70-tax-rate-on-the-rich-may-be-smart-politics-but-is-not-smart-economics/>
 (visited on 2020-06-24).
 
-\[9\] Richard Rubin. Republicans' Radical New Business-Tax Proposal,
-Simplified (Sort Of). December 2016. URL:
-<https://blogs.wsj.com/economics/2016/12/26/republicans-radical-new-business-tax-proposal-simplified-sort-of/>
+\[31\] Jason DeBacker and Anderson Frailey. Revenue and Macroeconomic
+Effects of a 70% Marginal Tax Rate. Quantitative Notes, 1:5, 2019.
+
+\[30\] Alan D. Viard and Sita Nataraj Slavov. Taxes, transfers,
+progressivity, and redistribution: Part III \\textbar AEI. Tax Notes,
+November 2018. URL:
+<https://www.aei.org/articles/taxes-transfers-progressivity-and-redistribution-part-3/>
 (visited on 2020-06-24).
 
-\[10\] Richard W Evans. Dynamic Analysis of Corporate Income Tax Rate
-Cut. Quantitative Notes, 4:6, 2017. URL:
-<https://www.openrg.com/reports/QN_CorpCut.pdf>.
-
-\[11\] Jason DeBacker. Estimating the Effects of Business Tax Reform on
-Output. Quantitative Notes, 2:4, 2017. URL:
-<https://www.openrg.com/reports/CCC_Output_QN.pdf>.
-
-\[12\] Richard W Evans and Haylee Ham. Government Revenue and
-Distributional Effects of Tax Cuts and Jobs Act. Quantitative Notes,
-3:4, 2017. URL: <https://www.openrg.com/reports/TCJA_taxcalc.pdf>.
-
-\[13\] Jason DeBacker. Impacts of Business Tax Reform on Investment
-Incentives for the Retail Industry. Quantitative Notes, 1:2, 2017. URL:
-<https://www.openrg.com/reports/Retail_QN_091817.pdf>.
-
-\[14\] Alex Brill. AEI Tax Brief: Child Tax Credit Options. September
-2017. URL:
-<https://www.aei.org/research-products/one-pager/aei-tax-brief-child-tax-credit-options/>
+\[29\] AEI. Charitable giving and the Tax Cuts and Jobs Act. Technical
+Report, AEI, June 2018. URL:
+<https://www.aei.org/research-products/report/charitable-giving-and-the-tax-cuts-and-jobs-act/>
 (visited on 2020-06-24).
 
-\[15\] Alex Brill. AEI Tax Brief: Increasing the Standard Deduction.
-September 2017. URL:
-<https://www.aei.org/research-products/one-pager/aei-tax-brief-increasing-the-standard-deduction/>
+\[28\] Alex Brill and Benedict Ippolito. The effects of tax reform on
+the medical deduction \\textbar AEI. Tax Notes, May 2018. URL:
+<https://www.aei.org/articles/the-effects-of-tax-reform-on-the-medical-deduction/>
 (visited on 2020-06-24).
 
-\[16\] Alex Brill. AEI Tax Brief: Repealing the personal exemption.
-September 2017. URL:
-<https://www.aei.org/research-products/one-pager/aei-tax-brief-repealing-the-personal-exemption/>
+\[27\] Reuben Fischer-Baum. Analysis \\textbar Will your taxes go up or
+down in 2018 under the new tax bill? Washington Post, January 2018. URL:
+<https://www.washingtonpost.com/graphics/2017/business/tax-bill-calculator/>
 (visited on 2020-06-24).
 
-\[17\] Alex Brill. Testimony: The opportunities for individual tax
-reform. September 2017.
+\[26\] Jason Furman. Some Preliminary Macroeconomics of the Tax Cuts and
+Jobs Act. January 2018. URL:
+<https://www.piie.com/system/files/documents/furman20180106ppt.pdf>.
 
-\[18\] Ernie Tedeschi. For the Non-Rich, the Child Tax Credit Is the Key
-to Tax Reform. The New York Times, October 2017. URL:
-<https://www.nytimes.com/interactive/2017/10/17/upshot/tax-reform-winners-losers-child-tax-credit.html>,
-<https://www.nytimes.com/interactive/2017/10/17/upshot/tax-reform-winners-losers-child-tax-credit.html>
+\[25\] Richard W Evans. Dynamic Analysis of EITC Expansion. Quantitative
+Notes, 2:14, 2018. URL:
+<https://www.openrg.com/reports/QN_EITC_v1.1.pdf>.
+
+\[24\] Jason DeBacker and Richard W Evans. Dynamic Analysis of Tax Cuts
+and Jobs Act. Quantitative Notes, 1:6, 2018. URL:
+<https://www.openrg.com/reports/QN_ogusa_TCJA.pdf>.
+
+\[23\] Tal Yellin and Sam Petulla. See how the tax bill affects your
+paycheck. CNN, December 2017. URL:
+<https://www.cnn.com/2017/12/13/politics/calculate-americans-taxes-senate-reform-bill/index.html>
 (visited on 2020-06-24).
 
-\[19\] Council of Economic Advisors. Evaluating the Anticipated Effects
-of Changes to the Mortgage Interest Deduction. Technical Report, Council
-of Economic Advisors, November 2017. URL:
-<https://www.whitehouse.gov/sites/whitehouse.gov/files/images/Effects%20of%20Changes%20to%20the%20Mortgage%20Interest%20Deduction%20FINAL.pdf>.
-
-\[20\] Quoctrung Bui and Ben Casselman. What the Tax Bill Would Look
-Like for 25,000 Middle-Class Families. The New York Times, November
-2017. URL:
-<https://www.nytimes.com/interactive/2017/11/28/upshot/what-the-tax-bill-would-look-like-for-25000-middle-class-families.html>,
-<https://www.nytimes.com/interactive/2017/11/28/upshot/what-the-tax-bill-would-look-like-for-25000-middle-class-families.html>
+\[22\] Ben Casselman. How to Build a Tax Calculator That's Actually
+Useful. The New York Times, December 2017. URL:
+<https://www.nytimes.com/2017/12/19/insider/how-to-build-a-tax-calculator-thats-actually-useful.html>
 (visited on 2020-06-24).
 
 \[21\] Adam Pearce, Quoctrung Bui, Ben Casselman, and Blacki Migliozzi.
@@ -106,240 +246,102 @@ December 2017. URL:
 <https://www.nytimes.com/interactive/2017/12/17/upshot/tax-calculator.html>
 (visited on 2020-06-24).
 
-\[22\] Ben Casselman. How to Build a Tax Calculator That's Actually
-Useful. The New York Times, December 2017. URL:
-<https://www.nytimes.com/2017/12/19/insider/how-to-build-a-tax-calculator-thats-actually-useful.html>
+\[20\] Quoctrung Bui and Ben Casselman. What the Tax Bill Would Look
+Like for 25,000 Middle-Class Families. The New York Times, November
+1.    URL:
+<https://www.nytimes.com/interactive/2017/11/28/upshot/what-the-tax-bill-would-look-like-for-25000-middle-class-families.html>,
+<https://www.nytimes.com/interactive/2017/11/28/upshot/what-the-tax-bill-would-look-like-for-25000-middle-class-families.html>
 (visited on 2020-06-24).
 
-\[23\] Tal Yellin and Sam Petulla. See how the tax bill affects your
-paycheck. CNN, December 2017. URL:
-<https://www.cnn.com/2017/12/13/politics/calculate-americans-taxes-senate-reform-bill/index.html>
+\[19\] Council of Economic Advisors. Evaluating the Anticipated Effects
+of Changes to the Mortgage Interest Deduction. Technical Report, Council
+of Economic Advisors, November 2017. URL:
+<https://www.whitehouse.gov/sites/whitehouse.gov/files/images/Effects%20of%20Changes%20to%20the%20Mortgage%20Interest%20Deduction%20FINAL.pdf>.
+
+\[18\] Ernie Tedeschi. For the Non-Rich, the Child Tax Credit Is the Key
+to Tax Reform. The New York Times, October 2017. URL:
+<https://www.nytimes.com/interactive/2017/10/17/upshot/tax-reform-winners-losers-child-tax-credit.html>,
+<https://www.nytimes.com/interactive/2017/10/17/upshot/tax-reform-winners-losers-child-tax-credit.html>
 (visited on 2020-06-24).
 
-\[24\] Jason DeBacker and Richard W Evans. Dynamic Analysis of Tax Cuts
-and Jobs Act. Quantitative Notes, 1:6, 2018. URL:
-<https://www.openrg.com/reports/QN_ogusa_TCJA.pdf>.
+\[17\] Alex Brill. Testimony: The opportunities for individual tax
+reform. September 2017.
 
-\[25\] Richard W Evans. Dynamic Analysis of EITC Expansion. Quantitative
-Notes, 2:14, 2018. URL:
-<https://www.openrg.com/reports/QN_EITC_v1.1.pdf>.
-
-\[26\] Jason Furman. Some Preliminary Macroeconomics of the Tax Cuts and
-Jobs Act. January 2018. URL:
-<https://www.piie.com/system/files/documents/furman20180106ppt.pdf>.
-
-\[27\] Reuben Fischer-Baum. Analysis \\textbar Will your taxes go up or
-down in 2018 under the new tax bill? Washington Post, January 2018. URL:
-<https://www.washingtonpost.com/graphics/2017/business/tax-bill-calculator/>
+\[16\] Alex Brill. AEI Tax Brief: Repealing the personal exemption.
+September 2017. URL:
+<https://www.aei.org/research-products/one-pager/aei-tax-brief-repealing-the-personal-exemption/>
 (visited on 2020-06-24).
 
-\[28\] Alex Brill and Benedict Ippolito. The effects of tax reform on
-the medical deduction \\textbar AEI. Tax Notes, May 2018. URL:
-<https://www.aei.org/articles/the-effects-of-tax-reform-on-the-medical-deduction/>
+\[15\] Alex Brill. AEI Tax Brief: Increasing the Standard Deduction.
+September 2017. URL:
+<https://www.aei.org/research-products/one-pager/aei-tax-brief-increasing-the-standard-deduction/>
 (visited on 2020-06-24).
 
-\[29\] AEI. Charitable giving and the Tax Cuts and Jobs Act. Technical
-Report, AEI, June 2018. URL:
-<https://www.aei.org/research-products/report/charitable-giving-and-the-tax-cuts-and-jobs-act/>
+\[14\] Alex Brill. AEI Tax Brief: Child Tax Credit Options. September
+1.    URL:
+<https://www.aei.org/research-products/one-pager/aei-tax-brief-child-tax-credit-options/>
 (visited on 2020-06-24).
 
-\[30\] Alan D. Viard and Sita Nataraj Slavov. Taxes, transfers,
-progressivity, and redistribution: Part III \\textbar AEI. Tax Notes,
-November 2018. URL:
-<https://www.aei.org/articles/taxes-transfers-progressivity-and-redistribution-part-3/>
+\[13\] Jason DeBacker. Impacts of Business Tax Reform on Investment
+Incentives for the Retail Industry. Quantitative Notes, 1:2, 2017. URL:
+<https://www.openrg.com/reports/Retail_QN_091817.pdf>.
+
+\[12\] Richard W Evans and Haylee Ham. Government Revenue and
+Distributional Effects of Tax Cuts and Jobs Act. Quantitative Notes,
+3:4, 2017. URL: <https://www.openrg.com/reports/TCJA_taxcalc.pdf>.
+
+\[11\] Jason DeBacker. Estimating the Effects of Business Tax Reform on
+Output. Quantitative Notes, 2:4, 2017. URL:
+<https://www.openrg.com/reports/CCC_Output_QN.pdf>.
+
+\[10\] Richard W Evans. Dynamic Analysis of Corporate Income Tax Rate
+Cut. Quantitative Notes, 4:6, 2017. URL:
+<https://www.openrg.com/reports/QN_CorpCut.pdf>.
+
+\[9\] Richard Rubin. Republicans' Radical New Business-Tax Proposal,
+Simplified (Sort Of). December 2016. URL:
+<https://blogs.wsj.com/economics/2016/12/26/republicans-radical-new-business-tax-proposal-simplified-sort-of/>
 (visited on 2020-06-24).
 
-\[31\] Jason DeBacker and Anderson Frailey. Revenue and Macroeconomic
-Effects of a 70% Marginal Tax Rate. Quantitative Notes, 1:5, 2019.
-
-\[32\] Aparna Mathur. A 70 percent tax rate on the rich may be smart
-politics, but is not smart economics \\textbar AEI. Bloomberg Tax,
-January 2019. URL:
-<https://www.aei.org/articles/a-70-tax-rate-on-the-rich-may-be-smart-politics-but-is-not-smart-economics/>
+\[8\] Dylan Matthews. House Republicans are proposing a big corporate
+tax cut that Walmart hates. Vox, December 2016. URL:
+<https://www.vox.com/2016/12/25/14069822/corporate-tax-border-adjustability>
 (visited on 2020-06-24).
 
-\[33\] Jason DeBacker, Richard W. Evans, and Kerk L. Phillips.
-Integrating Microsimulation Models of Tax Policy into a DGE
-Macroeconomic Model. Public Finance Review, 47(2):207--275, February
-2019. URL: <https://doi.org/10.1177/1091142118816744> (visited on
-2020-06-24), doi:10.1177/1091142118816744.
-
-\[34\] Aparna Mathur and Cody Kallen. Estimating the distributional
-implications of the Tax Cuts and Jobs Act. Technical Report, AEI,
-February 2019. URL:
-<https://www.aei.org/research-products/working-paper/estimating-the-distributional-implications-of-the-tax-cuts-and-jobs-act/>
+\[7\] Alex Brill. Tax reform: Ryan-Brady plan is a better way. Technical
+Report, AEI, October 2016. URL:
+<https://www.aei.org/research-products/report/tax-reform-ryan-brady-plan-is-a-better-way/>
 (visited on 2020-06-24).
 
-\[35\] Council of Economic Advisors. Economic Report of the President.
-Technical Report PR 45.9, Council of Economic Advisors, March 2019. URL:
-<https://www.govinfo.gov/content/pkg/ERP-2019/pdf/ERP-2019.pdf>.
-
-\[36\] Ernie Tedeschi. An Analysis of the Earned Basic Income Tax
-Credit. March 2019. URL:
-<https://drive.google.com/file/d/1Ko0kQXP7FEdzdvGJq4N7MmRbemFNH8Xp/view?mkt_tok=eyJpIjoiWVRRMFpqTXhOVGcwTkRBNSIsInQiOiJzNk5CWkpqOUlzeGc4Z0ZRUXYwSnRXT0ZZSGVwczNwa3A3UVwvUWdKaEVuc2E2TE91NUVUcjVEU1doMEdsSnpcL1BIVzE4U2NzeGZFOENBWmhiUlwvbDhUSUxsQVJ4cXJJTDJYcExsdElUV0xkMFFaRzJoMlRtTGNOZWM3RHZHeDNBUSJ9&usp=embed_facebook>
+\[6\] Richard Rubin. Why It's So Hard to Get Rid of Tax 'Loopholes'.
+August 2016. URL:
+<https://web.archive.org/web/20160819134156/http://blogs.wsj.com/economics/2016/08/18/why-its-so-hard-to-get-rid-of-tax-loopholes/>
 (visited on 2020-06-24).
 
-\[37\] Aparna Mathur. The Tax Cuts and Jobs Act: Anything but a simple
-tax reform \\textbar AEI. Bloomberg Tax, March 2019. URL:
-<https://www.aei.org/articles/the-tax-cuts-and-jobs-act-anything-but-a-simple-tax-reform/>
+\[5\] Aparna Mathur and Adele Hunter. Leaving Childless Taxpayers Behind
+in the Tax Code \\textbar AEI. Tax Notes, July 2016. Library Catalog:
+[www.aei.org](http://www.aei.org) Section: Public Economics. URL:
+<https://www.aei.org/articles/leaving-childless-taxpayers-behind-in-the-tax-code/>
 (visited on 2020-06-24).
 
-\[38\] Alan D. Viard. An Economic Analysis of the TCJA's Larger Standard
-Deduction. Tax Notes, April 2019. URL:
-<https://www.aei.org/wp-content/uploads/2019/04/On-the-Margin-April-1-2019.pdf>
+\[4\] Jim Tankersley. The search for the best middle-class tax cut.
+Washington Post, April 2016. URL:
+<https://www.washingtonpost.com/news/wonk/wp/2016/04/14/the-search-for-the-best-middle-class-tax-cut/>
 (visited on 2020-06-24).
 
-\[39\] Max Ghenis. Distributional analysis of Andrew Yang's Freedom
-Dividend. June 2019. URL:
-<https://medium.com/ubicenter/distributional-analysis-of-andrew-yangs-freedom-dividend-d8dab818bf1b>
+\[3\] Alex Brill. Understanding middle-class tax cuts. Technical Report,
+AEI, April 2016. URL:
+<https://www.aei.org/research-products/report/understanding-middle-class-tax-cuts/>
 (visited on 2020-06-24).
 
-\[40\] Lily L. Batchelder and David Kamin. Taxing the Rich: Issues and
-Options. SSRN Scholarly Paper ID 3452274, Social Science Research
-Network, Rochester, NY, September 2019.
-
-\[41\] Alan D. Viard and Sita Nataraj Slavov. The Wrong Way to Make
-Social Security and Medicare More Progressive. Tax Notes, September
-2019. URL:
-<https://www.taxnotes.com/tax-notes-federal/social-welfare-taxation/wrong-way-make-social-security-and-medicare-more-progressive/2019/09/16/29wpk>
+\[2\] Kevin Hassett. Reaching America\'s potential: Delivering growth
+and opportunity for all Americans. February 2016. URL:
+<https://www.aei.org/research-products/speech/statement-before-the-house-ways-and-means-committee/>
 (visited on 2020-06-24).
 
-\[42\] Aparna Mathur. Rethinking the Green New Deal: Using Climate
-Policy to Address Inequality. National Tax Journal, 70(4):693--722,
-December 2019. URL:
-<http://www.ntanet.org/NTJ/72/4/ntj-v72n04p693-722-Rehinking-the-Green-New-Deal.html>
-(visited on 2020-06-24), doi:10.17310/ntj.2019.4.03.
-
-\[43\] Jaeger Nelson and Kerk Phillips. Macroeconomic Effects of
-Reducing OASI Benefits: A Comparison of Seven Overlapping-Generations
-Models. National Tax Journal, 70(4):671--692, December 2019. URL:
-<http://www.ntanet.org/NTJ/72/4/ntj-v72n04p671-692-Macroeconomic-Effects-of-Reducing-OASI-Benefits.html>
-(visited on 2020-06-24), doi:10.17310/ntj.2019.4.02.
-
-\[44\] Matt Jensen. Transparency for Congress\'s Scorekeepers. National
-Affairs, 2020. URL:
-<https://www.nationalaffairs.com/publications/detail/transparency-for-congresss-scorekeepers>
-(visited on 2020-06-24).
-
-\[45\] Matt Jensen, Peter Metz, and Jason DeBacker. A static simulation
-of several personal income and payroll tax provisions from the Biden
-2020 reform. by Peter-Metz. 2020. URL:
-<https://compute.studio/PSLmodels/Tax-Brain/46307/> (visited on
-2020-11-03).
-
-\[46\] Kyle Pomerleau. Kyle Pomerleau on Twitter. March 2020. URL:
-<https://twitter.com/kpomerleau/status/1237439229627699200> (visited on
-2020-11-03).
-
-\[47\] Committee for a Responsible Federal Budget. Choices for Financing
-Medicare for All. Technical Report, Committee for a Responsible Federal
-Budget, March 2020. URL:
-<http://www.crfb.org/papers/choices-financing-medicare-all> (visited on
-2020-06-24).
-
-\[48\] Ernie Tedeschi. Updated Distribution of Household Rebate Ideas So
-Far. March 2020. URL:
-<https://medium.com/@ernietedeschi/updated-distribution-of-household-rebate-ideas-so-far-f46360034f9d>
-(visited on 2020-11-03).
-
-\[49\] Ernie Tedeschi. The Distribution of Household Rebate Ideas So
-Far. March 2020. URL:
-<https://medium.com/@ernietedeschi/the-distribution-of-household-rebate-ideas-so-far-2b71a8a19914>
-(visited on 2020-11-03).
-
-\[50\] Kyle Pomerleau. The CARES Act: Who will get a rebate and how
-much? March 2020. Section: Economics. URL:
-<https://www.aei.org/economics/the-care-act-who-will-get-a-rebate-and-how-much/>
-(visited on 2020-11-02).
-
-\[51\] Don Boyd. A New Synthetic Data Set for Tax Policy Analysis.
-Quantitative Notes, 2:7, May 2020. URL:
-<https://www.openrg.com/reports/SynData_QN.pdf>.
-
-\[52\] Kyle Pomerleau. Kyle Pomerleau on Twitter. May 2020. URL:
-<https://twitter.com/kpomerleau/status/1258497005598453761> (visited on
-2020-11-03).
-
-\[53\] Kyle Pomerleau. Eligible dependents in the CARES Act and HEROES
-Act economic relief payments. May 2020. Section: Economics. URL:
-<https://www.aei.org/economics/eligible-dependents-in-the-cares-act-and-heroes-act-economic-relief-payments/>
-(visited on 2020-11-02).
-
-\[54\] Kyle Pomerleau. An analysis of Joe Biden\'s tax proposals. June
-2020. Section: Economics. URL:
-<https://www.aei.org/research-products/report/an-analysis-of-joe-bidens-tax-proposals/>
-(visited on 2020-11-02).
-
-\[55\] Max Ghenis and Nate Silver. Poverty and inequality effects of new
-unemployment benefits, payroll tax cuts, and universal payments. July
-2020. URL: <https://covid.ubicenter.org/fpuc.html> (visited on
-2020-11-02).
-
-\[56\] Matt Jensen and Peter Metz. Effective tax rates on capital under
-current law and Joe Biden\'s tax proposal. September 2020. URL:
-<https://compute.studio/AEIEconomics/ccc-biden/> (visited on
-2020-11-03).
-
-\[57\] Kyle Pomerleau. The tax burden on business investment under Joe
-Biden's tax proposals. September 2020. Section: Economics. URL:
-<https://www.aei.org/research-products/report/the-tax-burden-on-business-investment-under-joe-bidens-tax-proposals/>
-(visited on 2020-11-02).
-
-\[58\] Richard Rubin. How Biden's Tax Plan Would Affect Five American
-Households. Wall Street Journal, September 2020. URL:
-<https://www.wsj.com/articles/how-bidens-tax-plan-might-affect-five-american-households-11599739200>.
-
-\[59\] Kyle Pomerleau. An analysis of Joe Biden's tax proposals, October
-2020 update. October 2020. Section: Economics. URL:
-<https://www.aei.org/research-products/report/an-analysis-of-joe-bidens-tax-proposals-october-2020-update/>.
-
-\[60\] Timothy Fitzgerald, Kevin Hassett, Cody Kallen, and Casey
-Mulligan. An Analysis of Vice President Biden's Economic Agenda: The
-Long Run Impacts of Its Regulation, Taxes, and Spending\*. October 2020.
+\[1\] Kevin Hassett. On the Dynamic Scoring of Fiscal Policy. July 2015.
 URL:
-<https://www.hoover.org/research/analysis-vice-president-bidens-economic-agenda-long-run-impacts>.
+<https://www.aei.org/press/on-the-dynamic-scoring-of-fiscal-policy/>
+(visited on 2020-06-24).
 
-\[61\] Kyle Pomerleau and Peter Metz. How would Joe Biden's tax
-proposals impact your tax liability? October 2020. Section: Economics.
-URL:
-<https://www.aei.org/economics/how-would-joe-bidens-tax-proposals-impact-your-tax-liability/>.
 
-\[62\] Kyle Pomerleau and Peter Metz. How would your taxes change under
-Joe Biden\'s tax plan? November 2020. URL:
-<https://compute.studio/AEIEconomics/Tax-Cruncher-Biden/>.
-
-\[63\] Angela Rachidi. Reducing the marriage penalty for low-income
-families. January 2021. URL:
-<https://www.aei.org/poverty-studies/reducing-the-marriage-tax-penalty-for-low-income-families/>.
-
-\[64\] Robert Orr and Samuel Hammond. Analysis of the Romney Child
-Allowance. February 2021. URL:
-<https://www.niskanencenter.org/wp-content/uploads/2021/02/Analysis-of-the-Romney-Child-Allowance_final.pdf>
-(visited on 2021-02-12).
-
-\[65\] Alex Brill, Kyle Pomerleau, and Grant Seiter. The tax benefits of
-parenthood: A history and analysis of current proposals. February 2021.
-Section: Economics. URL:
-<https://www.aei.org/research-products/report/the-tax-benefits-of-parenthood-a-history-and-analysis-of-current-proposals/>
-(visited on 2021-02-25).
-
-\[66\] Alex Brill, Kyle Pomerleau, and Grant Seiter. Pick your Child Tax
-Credit. March 2021. Section: Economics. URL:
-<https://www.aei.org/economics/pick-your-child-tax-credit/> (visited on
-2021-04-05).
-
-\[67\] Alex Brill. The American Rescue Plan's likely cost is way more
-than \$1.9 trillion. March 2021. URL:
-<https://www.aei.org/economics/the-american-rescue-plans-likely-cost-is-way-more-than-1-9-trillion/>
-(visited on 2021-03-05).
-
-\[68\] Alex Brill, Kyle Pomerleau, and Grant Seiter. How will the
-American Rescue Plan impact your 2021 tax liability? March 2021.
-Section: Economics. URL:
-<https://www.aei.org/economics/how-will-the-american-rescue-plan-impact-your-2021-tax-liability/>
-(visited on 2021-04-05).
-
-\[69\] Max Gehnis. California's basic income bill still needs work.
-April 2021. URL:
-<https://blog.ubicenter.org/20210403/california-ab65-calubi.html>
-(visited on 2021-04-06).


### PR DESCRIPTION
This PR reorders the use cases to list them in reverse chronological order per the suggestion of @donboyd5 in Issue #2616.