### PR TITLE
Divide CDCC parameters by 100

### DIFF
--- a/docs/guide/policy_params.md
+++ b/docs/guide/policy_params.md
@@ -756,41 +756,41 @@ _Out-of-Range Action:_ error
 
 
 ####  `CDCC_crt`  
-_Description:_ The maximum percentage rate for the CDCC; this percentage rate decreases as AGI rises above the CDCC_ps level.  
+_Description:_ The maximum rate for the CDCC; this rate decreases as AGI rises above the CDCC_ps level.  
 _Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
 _Can Be Inflation Indexed:_ False _Is Inflation Indexed:_ False  
 _Value Type:_ float  
 _Known Values:_  
-2013: 35.0  
-2014: 35.0  
-2015: 35.0  
-2016: 35.0  
-2017: 35.0  
-2018: 35.0  
-2019: 35.0  
-_Valid Range:_ min = 0 and max = 100  
+2013: 0.35  
+2014: 0.35  
+2015: 0.35  
+2016: 0.35  
+2017: 0.35  
+2018: 0.35  
+2019: 0.35  
+_Valid Range:_ min = 0 and max = 1  
 _Out-of-Range Action:_ error  
 
 
 ####  `CDCC_frt`  
-_Description:_ The minimum percentage rate for the first AGI phaseout of the CDCC.  
+_Description:_ The minimum rate for the first AGI phaseout of the CDCC.  
 _Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
 _Can Be Inflation Indexed:_ False _Is Inflation Indexed:_ False  
 _Value Type:_ float  
 _Known Values:_  
-2013: 20.0  
-2014: 20.0  
-2015: 20.0  
-2016: 20.0  
-2017: 20.0  
-2018: 20.0  
-2019: 20.0  
-_Valid Range:_ min = 0 and max = 100  
+2013: 0.20  
+2014: 0.20  
+2015: 0.20  
+2016: 0.20  
+2017: 0.20  
+2018: 0.20  
+2019: 0.20  
+_Valid Range:_ min = 0 and max = 1  
 _Out-of-Range Action:_ error  
 
 
 ####  `CDCC_prt`  
-_Description:_ The CDCC credit rate is reduced by this many percentage points for each dollary of AGI over the phase-out thresholds.  
+_Description:_ The CDCC credit rate is reduced by this many percentage points for each dollar of AGI over the phase-out thresholds.  
 _Notes:_ In the law, the credit rate is reduced by 1 percentage point for every $2,000 of AGI over the limit.  
 _Has An Effect When Using:_ _PUF data:_ True _CPS data:_ True  
 _Can Be Inflation Indexed:_ False _Is Inflation Indexed:_ False  

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -2159,7 +2159,7 @@ def F2441(MARS, earned_p, earned_s, f2441, CDCC_c, e32800,
         if c00100 > CDCC_ps2:
             crate = max(0., CDCC_frt -
                         max(((c00100 - CDCC_ps2) * CDCC_prt), 0.))
-    c33200 = c33000 * 0.01 * crate
+    c33200 = c33000 * crate
     # credit is limited by tax liability if not refundable
     if CDCC_refundable:
         c07180 = 0.

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -14074,21 +14074,21 @@
         "value": [
             {
                 "year": 2013,
-                "value": 35.0
+                "value": 0.350
             },
             {
                 "year": 2021,
-                "value": 50.0
+                "value": 0.500
             },
             {
                 "year": 2022,
-                "value": 35.0
+                "value": 0.350
             }
         ],
         "validators": {
             "range": {
                 "min": 0,
-                "max": 100
+                "max": 1
             }
         },
         "compatible_data": {
@@ -14108,13 +14108,13 @@
         "value": [
             {
                 "year": 2013,
-                "value": 20.0
+                "value": 0.2
             }
         ],
         "validators": {
             "range": {
                 "min": 0,
-                "max": 100
+                "max": 1
             }
         },
         "compatible_data": {


### PR DESCRIPTION
This PR divides the parameters `CDCC_crt` and `CDCC_frt` by 100 for consistency with the other parameters in Tax-Calculator.