### PR TITLE
Fix mode for tc cli

### DIFF
--- a/taxcalc.egg-info/requires.txt
+++ b/taxcalc.egg-info/requires.txt
@@ -1,3 +1,4 @@
+setuptools
 numpy
 pandas
 bokeh

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -221,8 +221,8 @@ def _compare_test_output_files():
     Private function that compares expected and actual tc --test output files;
     returns 0 if pass test, otherwise returns 1.
     """
-    explines = open(EXPECTED_TEST_OUTPUT_FILENAME, 'U').readlines()
-    actlines = open(ACTUAL_TEST_OUTPUT_FILENAME, 'U').readlines()
+    explines = open(EXPECTED_TEST_OUTPUT_FILENAME, 'r').readlines()
+    actlines = open(ACTUAL_TEST_OUTPUT_FILENAME, 'r').readlines()
     if ''.join(explines) == ''.join(actlines):
         sys.stdout.write('PASSED TEST\n')
         retcode = 0


### PR DESCRIPTION
This PR fixes the mode used in the `open()` function in a Tax-Calculator CLI test.  Also, `setuptools` is added to requirements. 