### PR TITLE
Better mapping of taxsim s corp income to taxcalc

### DIFF
--- a/taxcalc/validation/taxsim35/prepare_taxcalc_input.py
+++ b/taxcalc/validation/taxsim35/prepare_taxcalc_input.py
@@ -101,6 +101,7 @@ def translate(ivar):
     invar = ivar.rename(TAXSIM_TC_MAP, axis=1)
     invar["n24"] = ivar["dep17"]
     # Create variables for Tax-Calculator that aren't directly represented in TAXSIM
+    invar["e02000"] += invar["e26270"]  # add active scorp income to "otherprop" income from taxsim
     mstat = ivar["mstat"]
     assert np.all(np.logical_or(mstat == 1, mstat == 2))
     num_deps = ivar["depx"]


### PR DESCRIPTION
When doing the validation between TAXSIM and `taxcalc`, one needs to add the `scorp` income (which under TAXSIM is defined as active s-corp income) and `otherprop` (which in TAXSIM includes passive s corp income + some other items on Sch E) together to get `e02000`, which represents all Sch E income in `taxcalc`.