### PR TITLE
Avoid pandas deprecation warning

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -350,7 +350,7 @@ class Records(Data):
         # pylint: disable=no-member
         if self.ADJ.size > 0:
             # Interest income
-            self.e00300 *= self.ADJ['INT{}'.format(year)][self.agi_bin].values
+            self.e00300 *= self.ADJ[f'INT{year}'].iloc[self.agi_bin].values
 
     def _read_ratios(self, ratios):
         """


### PR DESCRIPTION
The current code produces this pandas deprecation warning:
```
     /Users/mrh/work/Tax-Calculator/taxcalc/records.py:353:
        FutureWarning:
     Series.__getitem__ treating keys as positions is deprecated.
        In a future version, integer keys will always be treated as
        labels (consistent with DataFrame behavior). To access a value
        by position, use `ser.iloc[pos]`
     self.e00300 *= self.ADJ['INT{}'.format(year)][self.agi_bin].values
```

This pull request makes the recommended code revision.
This revision causes no change in tax calculation output.
