### PR TITLE
Python version

### DIFF
--- a/.github/workflows/build_new_test_benchmark.yml
+++ b/.github/workflows/build_new_test_benchmark.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           activate-environment: taxcalc-dev
           environment-file: environment.yml
-          python-version: 3.9
+          python-version: 3.11
           auto-activate-base: false
 
       - name: Build
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./
         run: |
           pytest -m 'not requires_pufcsv and not pre_release and not local'
-          
+
       - name: Commit new test stats benchmark
         shell: bash -l {0}
         working-directory: ./taxcalc/tests

--- a/.github/workflows/check_jupyterbook.yml
+++ b/.github/workflows/check_jupyterbook.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           activate-environment: taxcalc-dev
           environment-file: environment.yml
-          python-version: 3.8
+          python-version: 3.11
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy Jupyter Book
 on:
   push:
-    branches:    
+    branches:
       - master
 jobs:
   build-and-deploy:
@@ -18,7 +18,7 @@ jobs:
         with:
           activate-environment: taxcalc-dev
           environment-file: environment.yml
-          python-version: 3.8
+          python-version: 3.11
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/.github/workflows/deploy_parameters_docs.yml
+++ b/.github/workflows/deploy_parameters_docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           activate-environment: taxcalc-dev
           environment-file: environment.yml
-          python-version: 3.9
+          python-version: 3.11
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/docs/contributing/dependencies.md
+++ b/docs/contributing/dependencies.md
@@ -2,7 +2,7 @@
 
 ## Python
 
-Tax-Calculator currently runs on Python 3.7, 3.8, and 3.9.
+Tax-Calculator currently runs on Python 3.9, 3.10, and 3.11.
 We generally support the three latest major Python releases.
 
 Updating the Python version requires modifying the following files:

--- a/docs/usage/starting.md
+++ b/docs/usage/starting.md
@@ -2,7 +2,7 @@ Getting started
 ===============
 
 Tax-Calculator packages are available for Windows, Mac, and Linux computers
-that have the free Anaconda Python 3.7, 3.8, or 3.9 distribution installed.
+that have the free Anaconda Python 3.9, 3.10, or 3.11 distribution installed.
 You can use Tax-Calculator without doing any Python programming, but the
 Anaconda distribution is required for Tax-Calculator to run.
 Take the following four steps to get started.


### PR DESCRIPTION
This PR bumps the Python version used in some of the GitHub Actions and in the docs, making it consistent with those versions we test against, 3.9-3.11.