### PR TITLE
Add s006_original variable to records_variables.json

### DIFF
--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -18,6 +18,13 @@ Classifier: Programming Language :: Python :: 3.11
 Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Description-Content-Type: text/markdown
 License-File: LICENSE
+Requires-Dist: setuptools
+Requires-Dist: numpy
+Requires-Dist: pandas
+Requires-Dist: bokeh
+Requires-Dist: numba
+Requires-Dist: requests
+Requires-Dist: paramtools
 
 | | |
 | --- | --- |

--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -18,13 +18,6 @@ Classifier: Programming Language :: Python :: 3.11
 Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Description-Content-Type: text/markdown
 License-File: LICENSE
-Requires-Dist: setuptools
-Requires-Dist: numpy
-Requires-Dist: pandas
-Requires-Dist: bokeh
-Requires-Dist: numba
-Requires-Dist: requests
-Requires-Dist: paramtools
 
 | | |
 | --- | --- |

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -491,6 +491,12 @@
       "form": {"2013-2016": "sample construction info"},
       "availability": "taxdata_puf, taxdata_cps"
     },
+    "s006_original": {
+      "type": "float",
+      "desc": "Sample weight before reweighting (not used in tax-calculation logic)",
+      "form": {"2013-2016": "sample construction info"},
+      "availability": "tax-microdata_tmd"
+    },
     "data_source": {
       "type": "int",
       "desc": "1 if unit is created primarily from IRS-SOI PUF data; 0 if created primarily from CPS data (not used in tax-calculation logic)",


### PR DESCRIPTION
The new `s006_original` variable is not used in tax calculations, but has been added to facilitate testing of the new `tmd.csv` file being generated in the [tax-microdata repository](https://github.com/PSLmodels/tax-microdata-benchmarking).