### PR TITLE
Update validation expected values for Tax-Calculator 4.0

### DIFF
--- a/taxcalc/validation/taxsim35/expected_differences/a17-taxdiffs-expect.csv
+++ b/taxcalc/validation/taxsim35/expected_differences/a17-taxdiffs-expect.csv
@@ -1,25 +1,25 @@
 ,# of differing records,max_diff,max_diff_index,max_diff_taxsim_val,max_diff_taxcalc_val
-iitax,2,0.5099999999999909,787,459.49,460.0
-statetax,0,0.0,no diff,no diff,no diff
-payrolltax,0,0.0,no diff,no diff,no diff
-mtr_inctax,1,-7.649999999999999,787,17.65,10.0
-mtr_state,0,0.0,no diff,no diff,no diff
-c00100,0,0.0,no diff,no diff,no diff
-e02300,0,0.0,no diff,no diff,no diff
-c02500,0,0.0,no diff,no diff,no diff
-post_phase_out_pe,0,0.0,no diff,no diff,no diff
-phased_out_pe,57,3.637978807091713e-12,806,16601.76,16601.760000000002
-c21040,0,0.0,no diff,no diff,no diff
-c04470,0,0.0,no diff,no diff,no diff
-c04800,0,0.0,no diff,no diff,no diff
-taxbc,6,-0.010000000009313226,217,93239.71,93239.7
-exemption_surtax,0,0.0,no diff,no diff,no diff
-gen_tax_credit,0,0.0,no diff,no diff,no diff
-non_refundable_child_odep_credit,0,0.0,no diff,no diff,no diff
-c11070,0,0.0,no diff,no diff,no diff
-c07180,0,0.0,no diff,no diff,no diff
-eitc,1,-0.51,787,0.51,0.0
-c62100,0,0.0,no diff,no diff,no diff
-amt_liability,0,0.0,no diff,no diff,no diff
-iitax_before_credits_ex_AMT,1,-1.4551915228366852e-11,362,65620.21,65620.20999999999
-recovery_rebate_credit,0,0.0,no diff,no diff,no diff
+iitax,2,0.51,787,459.49,460
+statetax,0,0,no diff,no diff,no diff
+payrolltax,0,0,no diff,no diff,no diff
+mtr_inctax,1,-7.65,787,17.65,10
+mtr_state,0,0,no diff,no diff,no diff
+c00100,0,0,no diff,no diff,no diff
+e02300,0,0,no diff,no diff,no diff
+c02500,0,0,no diff,no diff,no diff
+post_phase_out_pe,0,0,no diff,no diff,no diff
+phased_out_pe,60,3.64E-12,806,16601.76,16601.76
+c21040,0,0,no diff,no diff,no diff
+c04470,0,0,no diff,no diff,no diff
+c04800,0,0,no diff,no diff,no diff
+taxbc,6,-0.01,217,93239.71,93239.7
+exemption_surtax,0,0,no diff,no diff,no diff
+gen_tax_credit,0,0,no diff,no diff,no diff
+non_refundable_child_odep_credit,0,0,no diff,no diff,no diff
+c11070,0,0,no diff,no diff,no diff
+c07180,0,0,no diff,no diff,no diff
+eitc,1,-0.51,787,0.51,0
+c62100,0,0,no diff,no diff,no diff
+amt_liability,0,0,no diff,no diff,no diff
+iitax_before_credits_ex_AMT,1,-1.46E-11,362,65620.21,65620.21
+recovery_rebate_credit,0,0,no diff,no diff,no diff

--- a/taxcalc/validation/taxsim35/expected_differences/b17-taxdiffs-expect.csv
+++ b/taxcalc/validation/taxsim35/expected_differences/b17-taxdiffs-expect.csv
@@ -1,25 +1,25 @@
 ,# of differing records,max_diff,max_diff_index,max_diff_taxsim_val,max_diff_taxcalc_val
-iitax,496,-3122.1300000000047,464,346693.19,343571.06
-statetax,0,0.0,no diff,no diff,no diff
-payrolltax,944,15766.129999999997,464,42759.4,58525.53
-mtr_inctax,371,-13.869999999999997,644,41.87,28.0
-mtr_state,0,0.0,no diff,no diff,no diff
-c00100,563,-7884.170000000042,464,1028327.24,1020443.07
-e02300,0,0.0,no diff,no diff,no diff
-c02500,0,0.0,no diff,no diff,no diff
-post_phase_out_pe,24,566.7500000000005,739,3913.52,4480.27
-phased_out_pe,28,-566.75,739,12286.48,11719.73
-c21040,0,0.0,no diff,no diff,no diff
-c04470,0,0.0,no diff,no diff,no diff
-c04800,560,-8221.450000000012,141,399715.05,391493.6
-taxbc,984,-8184.830000000016,454,243008.07,234823.24
-exemption_surtax,0,0.0,no diff,no diff,no diff
-gen_tax_credit,0,0.0,no diff,no diff,no diff
-non_refundable_child_odep_credit,0,0.0,no diff,no diff,no diff
-c11070,0,0.0,no diff,no diff,no diff
-c07180,0,0.0,no diff,no diff,no diff
-eitc,0,0.0,no diff,no diff,no diff
-c62100,563,-7884.170000000042,464,1028327.24,1020443.07
-amt_liability,26,233.2,644,0.0,233.2
-iitax_before_credits_ex_AMT,507,-3122.1300000000047,464,346047.19,342925.06
-recovery_rebate_credit,0,0.0,no diff,no diff,no diff
+iitax,496,-3122.13,464,346693.19,343571.06
+statetax,0,0,no diff,no diff,no diff
+payrolltax,944,15766.13,464,42759.4,58525.53
+mtr_inctax,371,-13.87,644,41.87,28
+mtr_state,0,0,no diff,no diff,no diff
+c00100,563,-7884.17,464,1028327.24,1020443.07
+e02300,0,0,no diff,no diff,no diff
+c02500,0,0,no diff,no diff,no diff
+post_phase_out_pe,24,566.75,739,3913.52,4480.27
+phased_out_pe,30,-566.75,739,12286.48,11719.73
+c21040,0,0,no diff,no diff,no diff
+c04470,0,0,no diff,no diff,no diff
+c04800,560,-8221.45,141,399715.05,391493.6
+taxbc,984,-8184.83,454,243008.07,234823.24
+exemption_surtax,0,0,no diff,no diff,no diff
+gen_tax_credit,0,0,no diff,no diff,no diff
+non_refundable_child_odep_credit,0,0,no diff,no diff,no diff
+c11070,0,0,no diff,no diff,no diff
+c07180,0,0,no diff,no diff,no diff
+eitc,0,0,no diff,no diff,no diff
+c62100,563,-7884.17,464,1028327.24,1020443.07
+amt_liability,26,233.2,644,0,233.2
+iitax_before_credits_ex_AMT,509,-3122.13,464,346047.19,342925.06
+recovery_rebate_credit,0,0,no diff,no diff,no diff

--- a/taxcalc/validation/taxsim35/expected_differences/b21-taxdiffs-expect.csv
+++ b/taxcalc/validation/taxsim35/expected_differences/b21-taxdiffs-expect.csv
@@ -1,25 +1,25 @@
 ,# of differing records,max_diff,max_diff_index,max_diff_taxsim_val,max_diff_taxcalc_val
-iitax,1000,-27064.640000000014,621,363908.06,336843.42
-statetax,0,0.0,no diff,no diff,no diff
-payrolltax,927,17673.559999999998,359,38169.65,55843.21
-mtr_inctax,502,-25.15,252,25.15,0.0
-mtr_state,0,0.0,no diff,no diff,no diff
-c00100,588,-8838.319999999949,359,923028.96,914190.64
-e02300,0,0.0,no diff,no diff,no diff
-c02500,0,0.0,no diff,no diff,no diff
-post_phase_out_pe,0,0.0,no diff,no diff,no diff
-phased_out_pe,0,0.0,no diff,no diff,no diff
-c21040,0,0.0,no diff,no diff,no diff
-c04470,0,0.0,no diff,no diff,no diff
-c04800,1000,-79781.19999999995,557,863181.07,783399.87
-taxbc,1000,-33750.640000000014,11,236011.88,202261.24
-exemption_surtax,0,0.0,no diff,no diff,no diff
-gen_tax_credit,0,0.0,no diff,no diff,no diff
-non_refundable_child_odep_credit,6,255.17999999999984,202,1305.4,1560.58
-c11070,6,255.17999999999984,202,1305.4,1560.58
-c07180,0,0.0,no diff,no diff,no diff
-eitc,0,0.0,no diff,no diff,no diff
-c62100,1000,134481.40000000014,718,1516232.63,1650714.03
-amt_liability,325,20651.82,513,0.0,20651.82
-iitax_before_credits_ex_AMT,1000,-30301.54999999999,557,253689.5,223387.95
-recovery_rebate_credit,0,0.0,no diff,no diff,no diff
+iitax,1000,-26282.14,621,363908.06,337625.92
+statetax,0,0,no diff,no diff,no diff
+payrolltax,927,17673.56,359,38169.65,55843.21
+mtr_inctax,475,-25.15,252,25.15,0
+mtr_state,0,0,no diff,no diff,no diff
+c00100,588,-8838.32,359,923028.96,914190.64
+e02300,0,0,no diff,no diff,no diff
+c02500,0,0,no diff,no diff,no diff
+post_phase_out_pe,0,0,no diff,no diff,no diff
+phased_out_pe,0,0,no diff,no diff,no diff
+c21040,0,0,no diff,no diff,no diff
+c04470,0,0,no diff,no diff,no diff
+c04800,1000,-79781.2,557,863181.07,783399.87
+taxbc,1000,-32968.14,11,236011.88,203043.74
+exemption_surtax,0,0,no diff,no diff,no diff
+gen_tax_credit,0,0,no diff,no diff,no diff
+non_refundable_child_odep_credit,6,255.18,202,1305.4,1560.58
+c11070,6,255.18,202,1305.4,1560.58
+c07180,0,0,no diff,no diff,no diff
+eitc,0,0,no diff,no diff,no diff
+c62100,1000,134481.4,718,1516232.63,1650714.03
+amt_liability,317,20260.32,513,0,20260.32
+iitax_before_credits_ex_AMT,1000,-29519.05,557,253689.5,224170.45
+recovery_rebate_credit,0,0,no diff,no diff,no diff

--- a/taxcalc/validation/taxsim35/expected_differences/c17-taxdiffs-expect.csv
+++ b/taxcalc/validation/taxsim35/expected_differences/c17-taxdiffs-expect.csv
@@ -1,0 +1,25 @@
+,# of differing records,max_diff,max_diff_index,max_diff_taxsim_val,max_diff_taxcalc_val
+iitax,497,-3189.62,663,323202.99,320013.37
+statetax,0,0,no diff,no diff,no diff
+payrolltax,948,15766.12,464,44198.22,59964.34
+mtr_inctax,375,-15.12,629,43.12,28
+mtr_state,0,0,no diff,no diff,no diff
+c00100,574,-7884.17,464,1069778.22,1061894.05
+e02300,0,0,no diff,no diff,no diff
+c02500,0,0,no diff,no diff,no diff
+post_phase_out_pe,27,610.65,68,3079.35,3690
+phased_out_pe,30,-610.65,68,13120.65,12510
+c21040,651,-40340.92,328,40340.92,0
+c04470,356,23110.41,676,0,23110.41
+c04800,549,-13416.95,676,334915.13,321498.18
+taxbc,984,-8184.83,454,277251.56,269066.73
+exemption_surtax,0,0,no diff,no diff,no diff
+gen_tax_credit,0,0,no diff,no diff,no diff
+non_refundable_child_odep_credit,0,0,no diff,no diff,no diff
+c11070,0,0,no diff,no diff,no diff
+c07180,0,0,no diff,no diff,no diff
+eitc,0,0,no diff,no diff,no diff
+c62100,574,-16579.42,948,893325.42,876746
+amt_liability,47,4515.24,676,4171.03,8686.27
+iitax_before_credits_ex_AMT,511,-4427.59,676,90033.49,85605.9
+recovery_rebate_credit,0,0,no diff,no diff,no diff

--- a/taxcalc/validation/taxsim35/expected_differences/c19-taxdiffs-expect.csv
+++ b/taxcalc/validation/taxsim35/expected_differences/c19-taxdiffs-expect.csv
@@ -15,7 +15,7 @@ c04800,1000,-76708.95999999996,758,759327.73,682618.77
 taxbc,1000,-30693.73000000004,837,313966.08,283272.35
 exemption_surtax,0,0.0,no diff,no diff,no diff
 gen_tax_credit,0,0.0,no diff,no diff,no diff
-non_refundable_child_odep_credit,8,382.96000000000004,3,3128.1,3511.06
+non_refundable_child_odep_credit,10,382.96000000000004,3,3128.1,3511.06
 c11070,0,0.0,no diff,no diff,no diff
 c07180,0,0.0,no diff,no diff,no diff
 eitc,0,0.0,no diff,no diff,no diff


### PR DESCRIPTION
This PR updates the expected differences files used for the TAXSIM-35 validation of Tax-Calculator.

Note that all expected differences are at least as small in the most recent versions of Tax-Calculator.