### PR TITLE
Require numpy 1.26.* versions

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,7 +9,7 @@ build:
 requirements:
   build:
     - "python>=3.9, <3.13"
-    - "numpy>=1.20"
+    - "numpy>=1.26,<1.27"
     - "pandas>=2.2"
     - "bokeh>=2.4"
     - "paramtools>=0.18.2"
@@ -20,7 +20,7 @@ requirements:
 
   run:
     - "python>=3.9, <3.13"
-    - "numpy>=1.20"
+    - "numpy>=1.26,<1.27"
     - "pandas>=2.2"
     - "bokeh>=2.4"
     - "paramtools>=0.18.2"

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 - "python>=3.9, <3.13"
-- "numpy>=1.20"
+- "numpy>=1.26,<1.27"
 - "pandas>=2.2"
 - "bokeh>=2.4"
 - "paramtools>=0.18.2"


### PR DESCRIPTION
To ensure the use of a more modern numpy version, but not yet numpy 2.0.