### PR TITLE
Only upload codecov report on push to PSLmodels

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           pytest -m 'not requires_pufcsv and not requires_tmdcsv and not pre_release and not local' --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/Tax-Calculator')
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos


### PR DESCRIPTION
This PR updates the `build_and_test` GH action to only upload a codecov report on pushes to the PSLmodels repository of Tax-Calculator. Since codecov.io has required a token to upload reports, the action fails on forks that do not have a token.