### PR TITLE
Limit marshmallow version to work around paramtools bug

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,7 +12,8 @@ requirements:
     - "numpy>=1.26,<1.27"
     - "pandas>=2.2"
     - "bokeh>=2.4"
-    - "paramtools>=0.18.2"
+    - "marshmallow<3.22"    # to work around paramtools bug
+    - "paramtools>=0.18.2"  # requires marshmallow>=3.0
     - numba
     - curl
     - openpyxl
@@ -23,7 +24,8 @@ requirements:
     - "numpy>=1.26,<1.27"
     - "pandas>=2.2"
     - "bokeh>=2.4"
-    - "paramtools>=0.18.2"
+    - "marshmallow<3.22"    # to work around paramtools bug
+    - "paramtools>=0.18.2"  # requires marshmallow>=3.0
     - numba
     - curl
     - openpyxl

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,8 @@ dependencies:
 - "numpy>=1.26,<1.27"
 - "pandas>=2.2"
 - "bokeh>=2.4"
-- "paramtools>=0.18.2"
+- "marshmallow<3.22"    # to work around paramtools bug
+- "paramtools>=0.18.2"  # requires marshmallow>=3.0
 - numba
 - curl
 - pytest


### PR DESCRIPTION
The `paramtools` package does not work with `marshmallow` version 3.22.