### PR TITLE
Remove PT_qbid_limit_switch parameter and it's assocated False code

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ markers =
     extend_tcja
     itmded_vars
     pufcsv_agg
+    qbid
     reforms
     rtr
     stded

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -1217,7 +1217,7 @@ def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, c03260, e26270,
            PT_binc_w2_wages, PT_ubia_property, PT_qbid_rt,
            PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
            PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800,
-           PT_qbid_ps, PT_qbid_prt, qbided, PT_qbid_limit_switch):
+           PT_qbid_ps, PT_qbid_prt, qbided):
     """
     Calculates taxable income, c04800, and
     qualified business income deduction, qbided.
@@ -1275,8 +1275,6 @@ def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, c03260, e26270,
         QBID phaseout rate
     qbided: float
         Qualified Business Income (QBI) deduction
-    PT_qbid_limit_switch: bool
-        QBID wage and capital limitations switch
 
     Returns
     -------
@@ -1300,9 +1298,7 @@ def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, c03260, e26270,
             upper_thd = lower_thd + pre_qbid_taxinc_gap
             if PT_SSTB_income == 1 and pre_qbid_taxinc >= upper_thd:
                 qbided = 0.
-            # if PT_qbid_limit_switch is True, apply wage/capital
-            # limitations.
-            elif PT_qbid_limit_switch:
+            else:
                 wage_cap = PT_binc_w2_wages * PT_qbid_w2_wages_rt
                 alt_cap = (PT_binc_w2_wages * PT_qbid_alt_w2_wages_rt +
                            PT_ubia_property * PT_qbid_alt_property_rt)
@@ -1323,12 +1319,8 @@ def TaxInc(c00100, standard, c04470, c04600, MARS, e00900, c03260, e26270,
                     prt = (pre_qbid_taxinc - lower_thd) / pre_qbid_taxinc_gap
                     adj = prt * (qbid_adjusted - cap_adjusted)
                     qbided = qbid_adjusted - adj
-            # if PT_qbid_limit_switch is False, assume all taxpayers
-            # have sufficient wage expenses and capital income to avoid
-            # QBID limitations.
-            else:
-                qbided = qbid_before_limits
-        # apply taxinc cap (assuning cap rate is equal to PT_qbid_rt)
+
+        # apply taxinc cap (assuming cap rate is equal to PT_qbid_rt)
         net_cg = e00650 + c01000  # per line 34 in 2018 Pub 535 Worksheet 12-A
         taxinc_cap = PT_qbid_rt * max(0., pre_qbid_taxinc - net_cg)
         qbided = min(qbided, taxinc_cap)

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -18379,32 +18379,6 @@
             "cps": false
         }
     },
-    "PT_qbid_limit_switch": {
-        "title": "QBID wage and capital limitations switch.",
-        "description": "A value of True imposes wage/capital limitations. Note that neither the PUF nor CPS have data on wage expenses or capital income, and therefore all taxpayers are fully subject to the QBID limitations. A value of False assumes sufficient wage and capital income to avoid QBID limitations.",
-        "notes": "",
-        "section_1": "Personal Income",
-        "section_2": "Pass-Through",
-        "indexable": false,
-        "indexed": false,
-        "type": "bool",
-        "value": [
-            {
-                "year": 2013,
-                "value": true
-            }
-        ],
-        "validators": {
-            "range": {
-                "min": false,
-                "max": true
-            }
-        },
-        "compatible_data": {
-            "puf": false,
-            "cps": false
-        }
-    },
     "PT_qbid_ps": {
         "title": "QBID phaseout taxable income start",
         "description": "QBID begins to decrease when pre-QBID taxable income is above this level.",

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -551,7 +551,6 @@ PT_qbid_alt_w2_wages_rt = 0.25
 PT_qbid_alt_property_rt = 0.025
 PT_qbid_ps = [9e99, 9e99, 9e99, 9e99, 9e99]
 PT_qbid_prt = 0.0
-PT_qbid_limit_switch = True  # will want to test with False also
 
 # Input variable values for tests
 c00100 = [527860.66, 337675.10, 603700.00, 90700.00]
@@ -579,7 +578,7 @@ tuple0 = (
     PT_binc_w2_wages[0], PT_ubia_property[0], PT_qbid_rt,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[0],
-    PT_qbid_ps, PT_qbid_prt, qbided[0], PT_qbid_limit_switch)
+    PT_qbid_ps, PT_qbid_prt, qbided[0])
 expected0 = (490860.66, 0)
 tuple1 = (
     c00100[1], standard[1], c04470[1], c04600[1], MARS[1], e00900[1],
@@ -588,7 +587,7 @@ tuple1 = (
     PT_binc_w2_wages[1], PT_ubia_property[1], PT_qbid_rt,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[1],
-    PT_qbid_ps, PT_qbid_prt, qbided[1], PT_qbid_limit_switch)
+    PT_qbid_ps, PT_qbid_prt, qbided[1])
 expected1 = (284400.08, 4275.02)
 tuple2 = (
     c00100[2], standard[2], c04470[2], c04600[2], MARS[2], e00900[2],
@@ -597,7 +596,7 @@ tuple2 = (
     PT_binc_w2_wages[2], PT_ubia_property[2], PT_qbid_rt,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[2],
-    PT_qbid_ps, PT_qbid_prt, qbided[2], PT_qbid_limit_switch)
+    PT_qbid_ps, PT_qbid_prt, qbided[2])
 expected2 = (579300.00, 0)
 tuple3 = (
     c00100[3], standard[3], c04470[3], c04600[3], MARS[3], e00900[3],
@@ -607,7 +606,7 @@ tuple3 = (
     PT_binc_w2_wages[3], PT_ubia_property[3], PT_qbid_rt,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[3],
-    PT_qbid_ps, PT_qbid_prt, qbided[3], PT_qbid_limit_switch)
+    PT_qbid_ps, PT_qbid_prt, qbided[3])
 expected3 = (57500.00, 1200)
 
 

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -845,6 +845,7 @@ def test_itemded_component_amounts(year, cvname, hcname, puf_fullsample):
         raise ValueError(msg)
 
 
+@pytest.mark.qbid
 def test_qbid_calculation():
     """
     Test Calculator's QBID calculations using the six example filing units
@@ -884,42 +885,6 @@ def test_qbid_calculation():
     exp_taxinc = tpc_df.pre_qbid_taxinc
     assert np.allclose(act_taxinc, exp_taxinc)
     assert np.allclose(tc_df.qbided, tpc_df.qbid)
-
-
-def test_qbid_limit_switch():
-    """
-    Test Calculator's switch to implement wage/capital limitations
-    on QBI deduction.
-    """
-    cy = 2019
-    ref = {"PT_qbid_limit_switch": {2019: False}}
-
-    # filing unit has $500,000 in wages and $100,000 in QBI. Since
-    # the household is above the taxable income limitation threshold,
-    # with full wage/capital limitations, it does not receive a QBI
-    # deduction. With sufficent wage/capital to avoid the limitation,
-    # the filing unit receives a deduction of:
-    # $100,000 * 20% = $20,000.
-    VARS = 'RECID,MARS,e00200s,e00200p,e00200,e26270,e02000\n'
-    FUNIT = '1,2,250000,250000,500000,100000,100000'
-
-    funit_df = pd.read_csv(StringIO(VARS + FUNIT))
-    recs = Records(data=funit_df, start_year=cy,
-                   gfactors=None, weights=None)
-
-    calc_base = Calculator(policy=Policy(), records=recs)
-    calc_base.calc_all()
-
-    qbid_base = calc_base.array('qbided')
-    assert np.equal(qbid_base, 0)
-
-    pol_ref = Policy()
-    pol_ref.implement_reform(ref)
-    calc_ref = Calculator(policy=pol_ref, records=recs)
-    calc_ref.calc_all()
-
-    qbid_ref = calc_ref.array('qbided')
-    assert np.equal(qbid_ref, 20000)
 
 
 def test_calc_all_benefits_amounts(cps_subsample):


### PR DESCRIPTION
Fixes #2822 confusion without any restriction on ability to specify a `PT_qbid_limit_switch`==False reform (as discussed [here](https://github.com/PSLmodels/Tax-Calculator/issues/2822#issuecomment-2394224871)).