### PR TITLE
Fix handling of tmd_growfactors.csv file

### DIFF
--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: taxcalc
-Version: 4.3.0
+Version: 4.3.1
 Summary: taxcalc
 Home-page: https://github.com/PSLmodels/Tax-Calculator
 Download-URL: https://github.com/PSLmodels/Tax-Calculator

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1189,14 +1189,9 @@ class Calculator():
                 for pname in baseline.keys():
                     upda_value = getattr(updated, pname)
                     base_value = getattr(baseline, pname)
-                    is_diff = False
-                    if isinstance(upda_value, np.ndarray):
-                        if not np.allclose(upda_value, base_value):
-                            is_diff = True
-                    else:
-                        if upda_value != base_value:
-                            is_diff = True
-                    if is_diff:
+                    isarray = isinstance(upda_value, np.ndarray)
+                    if ((isarray and not np.allclose(upda_value, base_value))
+                        or (not is_array and upda_value != base_value)):
                         params_with_diff.append(pname)
                 if params_with_diff:
                     mdata_base = baseline.specification(meta_data=True)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1189,12 +1189,14 @@ class Calculator():
                 for pname in baseline.keys():
                     upda_value = getattr(updated, pname)
                     base_value = getattr(baseline, pname)
-                    if (
-                        (isinstance(upda_value, np.ndarray) and
-                         np.allclose(upda_value, base_value)) or
-                        (not isinstance(upda_value, np.ndarray) and
-                         upda_value != base_value)
-                    ):
+                    is_diff = False
+                    if isinstance(upda_value, np.ndarray):
+                        if not np.allclose(upda_value, base_value):
+                            is_diff = True
+                    else:
+                        if upda_value != base_value:
+                            is_diff = True
+                    if is_diff:
                         params_with_diff.append(pname)
                 if params_with_diff:
                     mdata_base = baseline.specification(meta_data=True)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -698,7 +698,8 @@ class Calculator():
                                   self.policy_param('FICA_ss_trt_employee') +
                                   self.policy_param('FICA_mc_trt_employer') +
                                   self.policy_param('FICA_mc_trt_employee')),
-                           0.5 * (self.policy_param('FICA_mc_trt_employer') + self.policy_param('FICA_mc_trt_employee')))
+                           0.5 * (self.policy_param('FICA_mc_trt_employer') +
+                                  self.policy_param('FICA_mc_trt_employee')))
         else:
             adj = 0.0
         # compute marginal tax rates
@@ -1189,9 +1190,11 @@ class Calculator():
                 for pname in baseline.keys():
                     upda_value = getattr(updated, pname)
                     base_value = getattr(baseline, pname)
-                    isarray = isinstance(upda_value, np.ndarray)
-                    if ((isarray and not np.allclose(upda_value, base_value))
-                        or (not is_array and upda_value != base_value)):
+                    is_array = isinstance(upda_value, np.ndarray)
+                    if (
+                        (is_array and not np.allclose(upda_value, base_value))
+                        or (is_array == False and upda_value != base_value)
+                    ):
                         params_with_diff.append(pname)
                 if params_with_diff:
                     mdata_base = baseline.specification(meta_data=True)

--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -38,7 +38,7 @@ class GrowFactors():
     which is for use with puf and cps data from the taxdata repository.
     """
 
-    PACKAGE_FILE_NAMES = ['growfactors.csv', 'tmd_growfactors.csv']
+    PACKAGE_FILE_NAMES = ['growfactors.csv']
     FILE_PATH = os.path.abspath(os.path.dirname(__file__))
 
     VALID_NAMES = set(['ABOOK', 'ACGNS', 'ACPIM', 'ACPIU',


### PR DESCRIPTION
The `tmd_growfactors.csv` file is no longer included in the `taxcalc` package.  Tax-Calculator can use that file, but it must be supplied by the user.

Also, fix a bug introduced by PR #2401 that made the CLI tool's policy reform documentation file contents wildly incorrect.