### PR TITLE
Add `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR adds a `pyproject.toml` file to avoid warnings and eventual deprecation of the ability build an editable package with `pip install -e  .` (see [Issue #11457 in the pypa/pip repo](https://github.com/pypa/pip/issues/11457)).