### PR TITLE
Simplify 'make package' command after pyproject.toml file has been added

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         shell: bash -l {0}
         run: |
-          pip install -e . --user --config-settings editable_mode=compat
+          pip install -e .
           pip install pytest-cov --user
           pip install pytest-pycodestyle --user
 

--- a/.github/workflows/check_jupyterbook.yml
+++ b/.github/workflows/check_jupyterbook.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pip install jupyter-book
           conda install -c pslmodels behresp
-          pip install -e . --config-settings editable_mode=compat
+          pip install -e .
           python docs/guide/make/make_uguide.py
           cd docs
           jb build .

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           pip install jupyter-book
           conda install -c pslmodels behresp
-          pip install -e . --config-settings editable_mode=compat
+          pip install -e .
           cd docs
           jb build .
 

--- a/.github/workflows/deploy_parameters_docs.yml
+++ b/.github/workflows/deploy_parameters_docs.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           pip install jupyter-book
           conda install -c pslmodels behresp
-          pip install -e . --config-settings editable_mode=compat
+          pip install -e .
           python docs/guide/make/make_uguide.py
           cd docs
           jb build .

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean:
 
 .PHONY=package
 package:
-	@pip install -e . --config-settings editable_mode=compat
+	@pip install -e .
 
 define pytest-setup
 rm -f taxcalc/tests/reforms_actual_init

--- a/taxcalc.egg-info/SOURCES.txt
+++ b/taxcalc.egg-info/SOURCES.txt
@@ -15,6 +15,7 @@ gitpr.bat
 gitsync
 gitsync.bat
 ppp.py
+pyproject.toml
 pytest.ini
 setup.py
 tctest-nojit.sh


### PR DESCRIPTION
@jdebacker added a `pyproject.toml` file in PR #2840, which seems to make the change in commit aeec409 unnecessary.