### PR TITLE
Generalize tmd_constructor in both Records and Policy classes

### DIFF
--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -53,7 +53,7 @@ class Policy(Parameters):
         'DependentCredit_before_CTC': 'is a removed parameter name',
         'FilerCredit_c': 'is a removed parameter name',
         'ALD_InvInc_ec_base_RyanBrady': 'is a removed parameter name',
-        # TODO: following parameter renamed in PR 2292 merged on 2019-04-15
+        # following parameter renamed in PR 2292 merged on 2019-04-15
         "cpi_offset": (
             "was renamed parameter_indexing_CPI_offset. "
             "See documentation for change in usage."
@@ -62,7 +62,7 @@ class Policy(Parameters):
             "was renamed parameter_indexing_CPI_offset. "
             "See documentation for change in usage."
         ),
-        # TODO: following parameters renamed in PR 2345 merged on 2019-06-24
+        # following parameters renamed in PR 2345 merged on 2019-06-24
         'PT_excl_rt':
         'was renamed PT_qbid_rt in release 2.4.0',
         'PT_excl_wagelim_thd':
@@ -102,17 +102,18 @@ class Policy(Parameters):
                         Policy.WAGE_INDEXED_PARAMS, **kwargs)
 
     @staticmethod
-    def tmd_constructor(growfactors_path):  # pragma: no cover
+    def tmd_constructor(growfactors: Path | GrowFactors):  # pragma: no cover
         """
         Static method returns a Policy object instantiated with TMD
         input data.  This convenience method works in a analogous way
         to Policy(), which returns a Policy object instantiated with
         non-TMD input data.
         """
-        assert isinstance(growfactors_path, Path)
-        gf_filename = str(growfactors_path)
-        tmd_growfactors = GrowFactors(growfactors_filename=gf_filename)
-        return Policy(gfactors=tmd_growfactors)
+        if isinstance(growfactors, Path):
+            growfactors = GrowFactors(growfactors_filename=str(growfactors))
+        else:
+            assert isinstance(growfactors, GrowFactors)
+        return Policy(gfactors=growfactors)
 
     @staticmethod
     def read_json_reform(obj):

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -235,7 +235,7 @@ class Records(Data):
     def tmd_constructor(
             data_path: Path,
             weights_path: Path,
-            growfactors_path: Path,
+            growfactors: Path | GrowFactors,
             exact_calculations=False,
     ):  # pragma: no cover
         """
@@ -250,12 +250,15 @@ class Records(Data):
         """
         assert isinstance(data_path, Path)
         assert isinstance(weights_path, Path)
-        assert isinstance(growfactors_path, Path)
+        if isinstance(growfactors, Path):
+            growfactors = GrowFactors(growfactors_filename=str(growfactors))
+        else:
+            assert isinstance(growfactors, GrowFactors)
         return Records(
             data=pd.read_csv(data_path),
             start_year=Records.TMDCSV_YEAR,
             weights=pd.read_csv(weights_path),
-            gfactors=GrowFactors(growfactors_filename=str(growfactors_path)),
+            gfactors=growfactors,
             adjust_ratios=None,
             exact_calculations=exact_calculations,
             weights_scale=1.0,


### PR DESCRIPTION
Allows growfactor argument to be either a Path object or a GrowFactors object.