### PR TITLE
Make a Policy object's last budget year be flexible

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,10 +9,10 @@ build:
 requirements:
   build:
     - "python>=3.10, <3.13"
-    - "numpy>=1.26,<1.27"
+    - "numpy>=1.26"
     - "pandas>=2.2"
     - "bokeh>=2.4"
-    - "paramtools>=0.18.3"
+    - "paramtools>=0.19.0"
     - numba
     - curl
     - openpyxl
@@ -20,10 +20,10 @@ requirements:
 
   run:
     - "python>=3.10, <3.13"
-    - "numpy>=1.26,<1.27"
+    - "numpy>=1.26"
     - "pandas>=2.2"
     - "bokeh>=2.4"
-    - "paramtools>=0.18.3"
+    - "paramtools>=0.19.0"
     - numba
     - curl
     - openpyxl

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,12 @@ channels:
   - conda-forge
 dependencies:
 - "python>=3.10, <3.13"
-- "numpy>=1.26,<1.27"
+- "numpy>=1.26"
 - "pandas>=2.2"
 - "bokeh>=2.4"
 - numba
 - curl
+- setuptools
 - pytest
 - pytest-xdist
 - pycodestyle
@@ -18,4 +19,4 @@ dependencies:
 - pip
 - pip:
     - jupyter-book
-    - "paramtools>=0.18.3"
+    - "paramtools>=0.19.0"

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,11 @@ config = {
     "include_package_data": True,
     "name": "taxcalc",
     "install_requires": [
-        "setuptools",
-        "numpy",
-        "pandas",
-        "bokeh",
+        "numpy>=1.26",
+        "pandas>=2.2",
+        "bokeh>=2.4",
         "numba",
-        "requests",
-        "paramtools>=0.18.3",
+        "paramtools>=0.19.0",
     ],
     "classifiers": [
         "Development Status :: 4 - Beta",

--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: taxcalc
-Version: 4.3.4
+Version: 4.3.5
 Summary: taxcalc
 Home-page: https://github.com/PSLmodels/Tax-Calculator
 Download-URL: https://github.com/PSLmodels/Tax-Calculator
@@ -18,13 +18,11 @@ Classifier: Programming Language :: Python :: 3.12
 Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Description-Content-Type: text/markdown
 License-File: LICENSE
-Requires-Dist: setuptools
-Requires-Dist: numpy
-Requires-Dist: pandas
-Requires-Dist: bokeh
+Requires-Dist: numpy>=1.26
+Requires-Dist: pandas>=2.2
+Requires-Dist: bokeh>=2.4
 Requires-Dist: numba
-Requires-Dist: requests
-Requires-Dist: paramtools>=0.18.3
+Requires-Dist: paramtools>=0.19.0
 
 | | |
 | --- | --- |

--- a/taxcalc.egg-info/requires.txt
+++ b/taxcalc.egg-info/requires.txt
@@ -1,7 +1,5 @@
-setuptools
-numpy
-pandas
-bokeh
+numpy>=1.26
+pandas>=2.2
+bokeh>=2.4
 numba
-requests
-paramtools>=0.18.3
+paramtools>=0.19.0

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -14,6 +14,6 @@ from taxcalc.taxcalcio import *
 from taxcalc.utils import *
 from taxcalc.cli import *
 
-__version__ = '4.3.5'
+__version__ = '4.3.5a'
 __min_python3_version__ = 10
 __max_python3_version__ = 12

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1110,7 +1110,7 @@ class Calculator():
         return param_dict
 
     @staticmethod
-    def reform_documentation(params, growfactors, policy_dicts=None):
+    def reform_documentation(params, policy_dicts=None):
         """
         Generate reform documentation versus current-law policy.
 
@@ -1119,9 +1119,6 @@ class Calculator():
         params: dict
             dictionary is structured like dict returned from
             the static Calculator.read_json_param_objects() method
-
-        growfactors: GrowFactors
-            GrowFactors object used to construct Calculator Policy object
 
         policy_dicts : list of dict or None
             each dictionary in list is a params['policy'] dictionary
@@ -1258,14 +1255,13 @@ class Calculator():
         # create Policy object with current-law-policy values
         gdiff_base = GrowDiff()
         gdiff_base.update_growdiff(params['growdiff_baseline'])
-        assert isinstance(growfactors, GrowFactors)
-        gfactors_clp = copy.deepcopy(growfactors)
+        gfactors_clp = GrowFactors()
         gdiff_base.apply_to(gfactors_clp)
         clp = Policy(gfactors=gfactors_clp)
         # create Policy object with post-reform values
         gdiff_resp = GrowDiff()
         gdiff_resp.update_growdiff(params['growdiff_response'])
-        gfactors_ref = copy.deepcopy(growfactors)
+        gfactors_ref = GrowFactors()
         gdiff_base.apply_to(gfactors_ref)
         gdiff_resp.apply_to(gfactors_ref)
         ref = Policy(gfactors=gfactors_ref)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1258,13 +1258,14 @@ class Calculator():
         # create Policy object with current-law-policy values
         gdiff_base = GrowDiff()
         gdiff_base.update_growdiff(params['growdiff_baseline'])
-        gfactors_clp = GrowFactors()
+        assert isinstance(growfactors, GrowFactors)
+        gfactors_clp = copy.deepcopy(growfactors)
         gdiff_base.apply_to(gfactors_clp)
         clp = Policy(gfactors=gfactors_clp)
         # create Policy object with post-reform values
         gdiff_resp = GrowDiff()
         gdiff_resp.update_growdiff(params['growdiff_response'])
-        gfactors_ref = GrowFactors()
+        gfactors_ref = copy.deepcopy(growfactors)
         gdiff_base.apply_to(gfactors_ref)
         gdiff_resp.apply_to(gfactors_ref)
         ref = Policy(gfactors=gfactors_ref)

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -1110,7 +1110,7 @@ class Calculator():
         return param_dict
 
     @staticmethod
-    def reform_documentation(params, policy_dicts=None):
+    def reform_documentation(params, growfactors, policy_dicts=None):
         """
         Generate reform documentation versus current-law policy.
 
@@ -1119,6 +1119,9 @@ class Calculator():
         params: dict
             dictionary is structured like dict returned from
             the static Calculator.read_json_param_objects() method
+
+        growfactors: GrowFactors
+            GrowFactors object used to construct Calculator Policy object
 
         policy_dicts : list of dict or None
             each dictionary in list is a params['policy'] dictionary

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -20,7 +20,8 @@ class Consumption(Parameters):
 
     Parameters
     ----------
-    none
+    last_budget_year: integer
+        user-defined last parameter extrapolation year
 
     Returns
     -------
@@ -28,14 +29,13 @@ class Consumption(Parameters):
     """
 
     JSON_START_YEAR = Policy.JSON_START_YEAR
-    DEFAULT_NUM_YEARS = Policy.DEFAULT_NUM_YEARS
     DEFAULTS_FILE_NAME = 'consumption.json'
     DEFAULTS_FILE_PATH = os.path.abspath(os.path.dirname(__file__))
 
-    def __init__(self):
+    def __init__(self, last_budget_year=Policy.LAST_BUDGET_YEAR):
         super().__init__()
-        self.initialize(Consumption.JSON_START_YEAR,
-                        Consumption.DEFAULT_NUM_YEARS)
+        nyrs = Policy.number_of_years(last_budget_year)
+        self.initialize(Consumption.JSON_START_YEAR, nyrs)
 
     @staticmethod
     def read_json_update(obj):

--- a/taxcalc/growdiff.py
+++ b/taxcalc/growdiff.py
@@ -20,7 +20,8 @@ class GrowDiff(Parameters):
 
     Parameters
     ----------
-    none
+    last_budget_year: integer
+        user-defined last parameter extrapolation year
 
     Returns
     -------
@@ -28,14 +29,13 @@ class GrowDiff(Parameters):
     """
 
     JSON_START_YEAR = Policy.JSON_START_YEAR
-    DEFAULT_NUM_YEARS = Policy.DEFAULT_NUM_YEARS
     DEFAULTS_FILE_NAME = 'growdiff.json'
     DEFAULTS_FILE_PATH = os.path.abspath(os.path.dirname(__file__))
 
-    def __init__(self):
+    def __init__(self, last_budget_year=Policy.LAST_BUDGET_YEAR):
         super().__init__()
-        self.initialize(GrowDiff.JSON_START_YEAR,
-                        GrowDiff.DEFAULT_NUM_YEARS)
+        nyrs = Policy.number_of_years(last_budget_year)
+        self.initialize(GrowDiff.JSON_START_YEAR, nyrs)
 
     @staticmethod
     def read_json_update(obj, topkey):
@@ -81,8 +81,3 @@ class GrowDiff(Parameters):
                 cyr = i + self.start_year
                 diff_array = getattr(self, _gfvn)
                 growfactors.update(gfvn, cyr, diff_array[i])
-
-    def set_rates(self):
-        """
-        Unimplemented base class method that is not used here.
-        """

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -98,19 +98,16 @@ class Parameters(pt.Parameters):
                 self.DEFAULTS_FILE_PATH,
                 self.DEFAULTS_FILE_NAME
             )
-
+        last_budget_year = start_year + num_years - 1
         if last_known_year is None:
             self._last_known_year = start_year
         else:
             assert last_known_year >= start_year
-            assert last_known_year <= self.LAST_BUDGET_YEAR
+            assert last_known_year <= last_budget_year
             self._last_known_year = last_known_year
-
         self._removed_params = removed or self.REMOVED_PARAMS
         self._redefined_params = redefined or self.REDEFINED_PARAMS
-
         self._wage_indexed = wage_indexed or self.WAGE_INDEXED_PARAMS
-
         if (
             (start_year or self.JSON_START_YEAR) and
             "initial_state" not in kwargs
@@ -118,6 +115,10 @@ class Parameters(pt.Parameters):
             kwargs["initial_state"] = {
                 "year": start_year or self.JSON_START_YEAR
             }
+        # update defaults to correspond to user-defined parameter years
+        self.defaults = super().get_defaults()
+        label = self.defaults["schema"]["labels"]["year"]
+        label["validators"]["range"]["max"] = last_budget_year
         super().__init__(**kwargs)
 
     def adjust(
@@ -774,7 +775,7 @@ class Parameters(pt.Parameters):
                 attr[1:], year=list(range(self.start_year, self.end_year + 1))
             )
         else:
-            raise AttributeError(f"{attr} not definied.")
+            raise AttributeError(f"{attr} is not defined.")
 
 
 TaxcalcReform = Union[str, Mapping[int, Any]]

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -261,20 +261,21 @@ class TaxCalcIO():
         if tax_year > max_tax_year:
             msg = f'TAXYEAR={tax_year} is greater than {max_tax_year}'
             self.errmsg += f'ERROR: {msg}\n'
-        min_tax_year = Policy.JSON_START_YEAR
         if self.puf_input_data:
             min_tax_year = max(  # pragma: no cover
                 Policy.JSON_START_YEAR, Records.PUFCSV_YEAR)
-        if self.cps_input_data:
+        elif self.cps_input_data:
             min_tax_year = max(
                 Policy.JSON_START_YEAR, Records.CPSCSV_YEAR)
-        if self.tmd_input_data:
+        elif self.tmd_input_data:
             min_tax_year = max(  # pragma: no cover
                 Policy.JSON_START_YEAR, Records.TMDCSV_YEAR)
+        else:
+            min_tax_year = Policy.JSON_START_YEAR
         if tax_year < min_tax_year:
             msg = f'TAXYEAR={tax_year} is less than {min_tax_year}'
             self.errmsg += f'ERROR: {msg}\n'
-        # tax_year out of range means cannot proceed with calculations
+        # tax_year out of valid range means cannot proceed with calculations
         if self.errmsg:
             return
         # get policy parameter dictionary from --baseline file

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -263,11 +263,14 @@ class TaxCalcIO():
             self.errmsg += f'ERROR: {msg}\n'
         min_tax_year = Policy.JSON_START_YEAR
         if self.puf_input_data:
-            min_tax_year = max(Policy.JSON_START_YEAR, Records.PUFCSV_YEAR)
+            min_tax_year = max(  # pragma: no cover
+                Policy.JSON_START_YEAR, Records.PUFCSV_YEAR)
         if self.cps_input_data:
-            min_tax_year = max(Policy.JSON_START_YEAR, Records.CPSCSV_YEAR)
+            min_tax_year = max(
+                Policy.JSON_START_YEAR, Records.CPSCSV_YEAR)
         if self.tmd_input_data:
-            min_tax_year = max(Policy.JSON_START_YEAR, Records.TMDCSV_YEAR)
+            min_tax_year = max(  # pragma: no cover
+                Policy.JSON_START_YEAR, Records.TMDCSV_YEAR)
         if tax_year < min_tax_year:
             msg = f'TAXYEAR={tax_year} is less than {min_tax_year}'
             self.errmsg += f'ERROR: {msg}\n'
@@ -398,10 +401,6 @@ class TaxCalcIO():
                            adjust_ratios=None,
                            exact_calculations=exact_calculations)
             recs_base = copy.deepcopy(recs)
-        if tax_year < recs.data_year:
-            msg = 'tax_year {} less than records.data_year {}'
-            msg = msg.format(tax_year, recs.data_year)
-            self.errmsg += 'ERROR: {}\n'.format(msg)
         # create Calculator objects
         self.calc = Calculator(policy=pol, records=recs,
                                verbose=True,

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -74,9 +74,9 @@ def test_make_calculator_with_policy_reform(cps_subsample):
     assert calc.current_year == year
     assert calc.policy_param('II_em') == 4000
     assert np.allclose(calc.policy_param('_II_em'),
-                       np.array([4000] * Policy.number_of_years()))
+                       np.array([4000] * pol.num_years))
     exp_STD_Aged = [[1600, 1300, 1300,
-                     1600, 1600]] * Policy.number_of_years()
+                     1600, 1600]] * pol.num_years
     assert np.allclose(calc.policy_param('_STD_Aged'),
                        np.array(exp_STD_Aged))
     assert np.allclose(calc.policy_param('STD_Aged'),
@@ -102,7 +102,7 @@ def test_make_calculator_with_multiyear_reform(cps_subsample):
     # check that Policy object embedded in Calculator object is correct
     assert calc.current_year == year
     assert calc.policy_param('II_em') == 3950
-    exp_II_em = [3900, 3950, 5000] + [6000] * (Policy.number_of_years() - 3)
+    exp_II_em = [3900, 3950, 5000] + [6000] * (pol.num_years - 3)
     assert np.allclose(calc.policy_param('_II_em'),
                        np.array(exp_II_em))
     calc.increment_year()

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -74,9 +74,9 @@ def test_make_calculator_with_policy_reform(cps_subsample):
     assert calc.current_year == year
     assert calc.policy_param('II_em') == 4000
     assert np.allclose(calc.policy_param('_II_em'),
-                       np.array([4000] * Policy.DEFAULT_NUM_YEARS))
+                       np.array([4000] * Policy.number_of_years()))
     exp_STD_Aged = [[1600, 1300, 1300,
-                     1600, 1600]] * Policy.DEFAULT_NUM_YEARS
+                     1600, 1600]] * Policy.number_of_years()
     assert np.allclose(calc.policy_param('_STD_Aged'),
                        np.array(exp_STD_Aged))
     assert np.allclose(calc.policy_param('STD_Aged'),
@@ -100,10 +100,9 @@ def test_make_calculator_with_multiyear_reform(cps_subsample):
     # create a Calculator object using this policy-reform
     calc = Calculator(policy=pol, records=rec)
     # check that Policy object embedded in Calculator object is correct
-    assert pol.num_years == Policy.DEFAULT_NUM_YEARS
     assert calc.current_year == year
     assert calc.policy_param('II_em') == 3950
-    exp_II_em = [3900, 3950, 5000] + [6000] * (Policy.DEFAULT_NUM_YEARS - 3)
+    exp_II_em = [3900, 3950, 5000] + [6000] * (Policy.number_of_years() - 3)
     assert np.allclose(calc.policy_param('_II_em'),
                        np.array(exp_II_em))
     calc.increment_year()

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -8,9 +8,8 @@ import copy
 from taxcalc import Policy, Records, Calculator, Consumption
 
 
-def test_year_consistency():
+def test_start_year_consistency():
     assert Consumption.JSON_START_YEAR == Policy.JSON_START_YEAR
-    assert Consumption.DEFAULT_NUM_YEARS == Policy.DEFAULT_NUM_YEARS
 
 
 def test_validity_of_consumption_vars_set():
@@ -31,23 +30,23 @@ def test_update_consumption():
                             2015: 0.80}
     }
     consump.update_consumption(revision)
-    expected_mpc_e20400 = np.full((Consumption.DEFAULT_NUM_YEARS,), 0.06)
+    expected_mpc_e20400 = np.full((consump.num_years,), 0.06)
     expected_mpc_e20400[0] = 0.0
     expected_mpc_e20400[1] = 0.05
     assert np.allclose(consump._MPC_e20400,
                        expected_mpc_e20400,
                        rtol=0.0)
     assert np.allclose(consump._MPC_e17500,
-                       np.zeros((Consumption.DEFAULT_NUM_YEARS,)),
+                       np.zeros((consump.num_years,)),
                        rtol=0.0)
-    expected_ben_mcare_value = np.full((Consumption.DEFAULT_NUM_YEARS,), 0.80)
+    expected_ben_mcare_value = np.full((consump.num_years,), 0.80)
     expected_ben_mcare_value[0] = 1.0
     expected_ben_mcare_value[1] = 0.75
     assert np.allclose(consump._BEN_mcare_value,
                        expected_ben_mcare_value,
                        rtol=0.0)
     assert np.allclose(consump._BEN_snap_value,
-                       np.ones((Consumption.DEFAULT_NUM_YEARS,)),
+                       np.ones((consump.num_years,)),
                        rtol=0.0)
     consump.set_year(2015)
     assert consump.current_year == 2015

--- a/taxcalc/tests/test_cpscsv.py
+++ b/taxcalc/tests/test_cpscsv.py
@@ -184,7 +184,7 @@ def test_flexible_last_budget_year(cps_fullsample):
         calc = Calculator(policy=pol, records=rec)
         return calc
 
-    def flexible_calculator(growdiff_dictionary, last_b_year, num_years):
+    def flexible_calculator(growdiff_dictionary, last_b_year):
         """
         Return CPS-based Calculator object using custom LAST_BUDGET_YEAR.
         """
@@ -203,8 +203,7 @@ def test_flexible_last_budget_year(cps_fullsample):
     cdef.calc_all()
     iitax_def = round(cdef.weighted_total('iitax'))
 
-    num_years = tax_calc_year - Policy.JSON_START_YEAR + 1
-    cflx = flexible_calculator(growdiff_dict, tax_calc_year, num_years)
+    cflx = flexible_calculator(growdiff_dict, tax_calc_year)
     cflx.advance_to_year(tax_calc_year)
     cflx.calc_all()
     iitax_flx = round(cflx.weighted_total('iitax'))

--- a/taxcalc/tests/test_growdiff.py
+++ b/taxcalc/tests/test_growdiff.py
@@ -8,9 +8,8 @@ import pytest
 from taxcalc import GrowDiff, GrowFactors, Policy
 
 
-def test_year_consistency():
+def test_start_year_consistency():
     assert GrowDiff.JSON_START_YEAR == Policy.JSON_START_YEAR
-    assert GrowDiff.DEFAULT_NUM_YEARS == Policy.DEFAULT_NUM_YEARS
 
 
 def test_update_and_apply_growdiff():
@@ -22,14 +21,13 @@ def test_update_and_apply_growdiff():
     }
     gdiff.update_growdiff(diffs)
     expected_wage_diffs = [0.00, 0.01, 0.01, 0.02, 0.02]
-    extra_years = GrowDiff.DEFAULT_NUM_YEARS - len(expected_wage_diffs)
+    extra_years = gdiff.num_years - len(expected_wage_diffs)
     expected_wage_diffs.extend([0.02] * extra_years)
     assert np.allclose(gdiff._AWAGE, expected_wage_diffs, atol=0.0, rtol=0.0)
     # apply growdiff to GrowFactors instance
     gf = GrowFactors()
-    syr = GrowDiff.JSON_START_YEAR
-    nyrs = GrowDiff.DEFAULT_NUM_YEARS
-    lyr = syr + nyrs - 1
+    syr = gdiff.start_year
+    lyr = gdiff.end_year
     pir_pre = gf.price_inflation_rates(syr, lyr)
     wgr_pre = gf.wage_growth_rates(syr, lyr)
     gfactors = GrowFactors()
@@ -37,7 +35,7 @@ def test_update_and_apply_growdiff():
     pir_pst = gfactors.price_inflation_rates(syr, lyr)
     wgr_pst = gfactors.wage_growth_rates(syr, lyr)
     expected_wgr_pst = [wgr_pre[i] + expected_wage_diffs[i]
-                        for i in range(0, nyrs)]
+                        for i in range(0, gdiff.num_years)]
     assert np.allclose(pir_pre, pir_pst, atol=0.0, rtol=0.0)
     assert np.allclose(wgr_pst, expected_wgr_pst, atol=1.0e-9, rtol=0.0)
 

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -247,9 +247,9 @@ def test_multi_year_reform():
     Test multi-year reform involving 1D and 2D parameters.
     """
     # specify dimensions of policy Policy object
-    syr = Policy.JSON_START_YEAR
-    nyrs = Policy.DEFAULT_NUM_YEARS
     pol = Policy()
+    syr = pol.start_year
+    nyrs = pol.num_years
     iratelist = pol.inflation_rates()
     ifactor = {}
     for i in range(0, nyrs):


### PR DESCRIPTION
The `LAST_BUDGET_YEAR`, which is a constant attribute of the Policy class, is currently set to 2034.   There is a need to be able to instantiate Policy objects that have their last budget year different from `LAST_BUDGET_YEAR`.   The main need is to be able to use [TMD input data](https://github.com/PSLmodels/tax-microdata-benchmarking) that include weights and growfactors extending out to 2074.  For much of 2024 the only way to use the TMD data to simulate beyond 2034 was to create a customized version of Tax-Calculator using the code on the `thru74` branch in PR #2755.

Recently, @jdebacker had the vision to see that there was a way to revise Tax-Calculator code so that by default it would use `LAST_BUDGET_YEAR` but the code would have the flexibility to allow users to specify Policy objects with last budget year greater (or less) than `LAST_BUDGET_YEAR`.  @jdebacker worked with @hdoupe to revise [ParamTools](https://github.com/PSLmodels/ParamTools), which is the foundation of the Policy class, so that it would be possible to add this flexibility.  Then in PR #2846, @jdebacker implemented the code changes for the Python API made possible with the new `ParamTools` 0.19.0 version.  This PR builds on @jdebacker's PR #2846.

The remaining minor task of using the new Python API in `taxcalcio.py` to make the Tax-Calculator CLI tool, `tc`, have the same last budget year flexibility is being handled by @martinholmer, who is a frequent CLI user.

.

The new flexibility added in this PR is illustrated below with two different examples:
* estimating 2070 income tax revenue under a 2060 reform that increased aggregate wages using the Python API is demonstrated in this [comment](https://github.com/PSLmodels/Tax-Calculator/pull/2856#issuecomment-2549680417)
* estimating 2070 income tax revenue under current-law policy using the CLI tool, `tc`, is demonstrated in this [comment](https://github.com/PSLmodels/Tax-Calculator/pull/2856#issuecomment-2549692452)

Also, the 2070 results generated in these two examples were compared to 2070 results generated by a custom Tax-Calculator package constructed using the `thru74` branch (in PR #2755.   The results were identical as expected.
