### PR TITLE
Eliminate pandas FutureWarning in the `test_compare.py` module

### DIFF
--- a/taxcalc/tests/test_compare.py
+++ b/taxcalc/tests/test_compare.py
@@ -202,7 +202,7 @@ def comparison(cname, calc, cmpdata, ofile):
     vardf['cvar'] = cvar
     # construct AGI table
     vardf = add_income_table_row_variable(vardf, 'c00100', SOI_AGI_BINS)
-    gbydf = vardf.groupby('table_row', as_index=False)
+    gbydf = vardf.groupby('table_row', as_index=False, observed=True)
     # write AGI table with ALL row at bottom of ofile
     ofile.write(f'TABLE for {cname.split(":")[1]}\n')
     results = '{:23s}\t{:8.3f}\t{:8.3f}\t{:+6.1f}\n'


### PR DESCRIPTION
No change in tax calculation logic or in test logic; just eliminates a FutureWarning message generated by the testing.

See this [issue comment](https://github.com/PSLmodels/Tax-Calculator/issues/2875#issuecomment-2688642625) for details on the FutureWarning.