### PR TITLE
Lengthen the waiting time for the 64 test reforms to complete execution

### DIFF
--- a/taxcalc/tests/conftest.py
+++ b/taxcalc/tests/conftest.py
@@ -78,7 +78,7 @@ def fixture_test_reforms(tests_path):
     actfile_path = os.path.join(tests_path, 'reforms_actual.csv')
     afiles = os.path.join(tests_path, 'reform_actual_*.csv')
     wait_secs = 1
-    max_waits = 180
+    max_waits = 240
     # test_reforms setup
     if handling_logic:
         # remove reforms_actual.csv file if exists


### PR DESCRIPTION
No change in tax calculation logic or in test logic; the only change is waiting somewhat longer for the 64 reform tests to complete execution.  Note that these 64 tests use private `puf.csv` data, and therefore, these tests are not run on GitHub.