### PR TITLE
drop Python 3.9 in docs

### DIFF
--- a/docs/usage/starting.md
+++ b/docs/usage/starting.md
@@ -2,7 +2,7 @@ Getting started
 ===============
 
 Tax-Calculator packages are available for Windows, Mac, and Linux computers
-that have the free Anaconda Python 3.9, 3.10, 3.11, or 3.12 distribution
+that have the free Anaconda Python 3.10, 3.11, or 3.12 distribution
 installed.  You can use Tax-Calculator without doing any Python programming,
 but the Anaconda distribution is required for Tax-Calculator to run.
 Take the following four steps to get started.


### PR DESCRIPTION
This PR is to drop Python 3.9 in the documentation. 

I've seen errors coming up when trying to run Tax-Calc under Python 3.9 locally. 

This also matches with the Python version requirement in [taxcalc-dev environment](https://github.com/PSLmodels/Tax-Calculator/blob/master/environment.yml).

