### PR TITLE
Make ACTC_c parameter be inflation indexed in the ext.json reform.

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,7 +11,7 @@ requirements:
     - "python>=3.10, <3.13"
     - "numpy>=1.26"
     - "pandas>=2.2"
-    - "bokeh>=2.4"
+    - "bokeh>=3.7"
     - "paramtools>=0.19.0"
     - numba
     - curl
@@ -22,7 +22,7 @@ requirements:
     - "python>=3.10, <3.13"
     - "numpy>=1.26"
     - "pandas>=2.2"
-    - "bokeh>=2.4"
+    - "bokeh>=3.7"
     - "paramtools>=0.19.0"
     - numba
     - curl

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - "python>=3.10, <3.13"
 - "numpy>=1.26"
 - "pandas>=2.2"
-- "bokeh>=2.4"
+- "bokeh>=3.7"
 - numba
 - curl
 - setuptools

--- a/extend_tcja.py
+++ b/extend_tcja.py
@@ -51,7 +51,7 @@ TCJA_PARAMETERS = {
     "PT_brk7": {"indexed": True, "category": 1},
     # category 2 ...
     "CTC_c": {"indexed": False, "category": 2},
-    "ACTC_c": {"indexed": False, "category": 2},
+    "ACTC_c": {"indexed": True, "category": 2},
     "ODC_c": {"indexed": False, "category": 2},
     "CTC_ps": {"indexed": False, "category": 2},
     "ACTC_Income_thd": {"indexed": False, "category": 2},

--- a/taxcalc/reforms/ext.json
+++ b/taxcalc/reforms/ext.json
@@ -1,5 +1,5 @@
 // REFORM TO EXTEND TEMPORARY TCJA PROVISIONS BEYOND 2025
-// USING TAX-CALCULATOR 4.4.1
+// USING TAX-CALCULATOR 4.5.0
 // WITH 2025-to-2026 INDEXING FACTOR = 1.022300
 //  AND 2028-to-2029 INDEXING FACTOR = 1.022600
 {
@@ -32,7 +32,10 @@
     "PT_rt7": {"2026": 0.37},
     "PT_brk7": {"2026": [9e+99, 9e+99, 9e+99, 9e+99, 9e+99]},
     "CTC_c": {"2026": 2000.00},
-    "ACTC_c": {"2026": 1700.00},
+    "ACTC_c": {"2026": 1776.67},
+    "ACTC_c-indexed": {"2026": true},
+    "ACTC_c": {"2032": 2000.00},
+    "ACTC_c-indexed": {"2032": false},
     "ODC_c": {"2026": 500.00},
     "CTC_ps": {"2026": [200000.0, 400000.0, 200000.0, 200000.0, 400000.0]},
     "ACTC_Income_thd": {"2026": 2500.00},

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -386,4 +386,4 @@ def test_ext_reform(tests_path):
     iitax_ext = calc_ext.array('iitax')
     rdiff = iitax_ext - iitax_end
     weighted_sum_rdiff = (rdiff * calc_end.array('s006')).sum() * 1.0e-9
-    assert np.allclose([weighted_sum_rdiff], [-214.11], rtol=0.0, atol=0.01)
+    assert np.allclose([weighted_sum_rdiff], [-205.769], rtol=0.0, atol=0.01)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1160,7 +1160,7 @@ def xtr_graph_plot(data,
              line_color='blue', line_width=3, legend_label='Baseline')
     fig.line(lines.index, lines.reform,
              line_color='red', line_width=3, legend_label='Reform')
-    fig.circle(0, 0, visible=False)  # force zero to be included on y axis
+    fig.scatter(0, 0, visible=False)  # force zero to be included on y axis
     if xlabel == '':
         xlabel = data['xlabel']
     fig.xaxis.axis_label = xlabel
@@ -1295,8 +1295,8 @@ def pch_graph_plot(data,
     fig.title.text_font_size = '12pt'
     line = data['line']
     fig.line(line.index, line.pch, line_color='blue', line_width=3)
-    fig.circle(0, 0, visible=False)  # force zero to be included on y axis
-    zero_grid_line_range = range(0, 101)
+    fig.scatter(0, 0, visible=False)  # force zero to be included on y axis
+    zero_grid_line_range = line.index
     zero_grid_line_height = [0] * len(zero_grid_line_range)
     fig.line(zero_grid_line_range, zero_grid_line_height,
              line_color='black', line_width=1)
@@ -1311,13 +1311,8 @@ def pch_graph_plot(data,
     fig.yaxis.axis_label_text_font_size = '12pt'
     fig.yaxis.axis_label_text_font_style = 'normal'
     fig.yaxis[0].formatter = PrintfTickFormatter(format='%.1f')
-    # bokeh cannot save this fig saying:
-    #   bokeh.core.serialization.SerializationError:
-    #   can't serialize <class 'range'>
-    # so the "return fig" statement is replaced by Python's implicit
-    # "return None" until the above logic can be made compatible with
-    # modern bokeh packages
-    # return fig
+    return fig
+
 
 
 def write_graph_file(figure, filename, title):


### PR DESCRIPTION
Resolves issues #2853 and #2881.

The only CTC-related parameter that is inflation indexed under TCJA is `ACTC_c` as documented in this [CRS paper](https://www.congress.gov/crs-product/R41873).  The `CTC_c` and `ODC_c` parameters have never been inflation indexed.

After making these changes in `taxcalc/reforms/ext.json`, the 2035 change in income tax liability generated by the `ext.json` reform goes from about -338.0 billion dollars to about -339.7 billion dollars, which is a change of about 1.7 billion dollars (or about one-half of one percent).
