### PR TITLE
Fix cosmetic problems in source code and in CLI tool error reporting

### DIFF
--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -169,7 +169,10 @@ def cli_tc_main():
                         reform=args.reform, assump=args.assump,
                         outdir=args.outdir)
     if tcio.errmsg:
-        sys.stderr.write(tcio.errmsg)
+        if tcio.errmsg.endswith('\n'):
+            sys.stderr.write(tcio.errmsg)
+        else:
+            sys.stderr.write(tcio.errmsg + '\n')
         sys.stderr.write('USAGE: tc --help\n')
         return 1
     aging = (
@@ -188,7 +191,10 @@ def cli_tc_main():
         xtime = time.time() - stime
         sys.stdout.write(f'TIMINGS: init time = {xtime:.2f} secs\n')
     if tcio.errmsg:
-        sys.stderr.write(tcio.errmsg)
+        if tcio.errmsg.endswith('\n'):
+            sys.stderr.write(tcio.errmsg)
+        else:
+            sys.stderr.write(tcio.errmsg + '\n')
         sys.stderr.write('USAGE: tc --help\n')
         return 1
     dumpvar_set = None
@@ -198,7 +204,10 @@ def cli_tc_main():
                 dump_vars_str = dfile.read()
             dumpvar_set = tcio.custom_dump_variables(dump_vars_str)
             if tcio.errmsg:
-                sys.stderr.write(tcio.errmsg)
+                if tcio.errmsg.endswith('\n'):
+                    sys.stderr.write(tcio.errmsg)
+                else:
+                    sys.stderr.write(tcio.errmsg + '\n')
                 sys.stderr.write('USAGE: tc --help\n')
                 return 1
         else:

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1314,7 +1314,6 @@ def pch_graph_plot(data,
     return fig
 
 
-
 def write_graph_file(figure, filename, title):
     """
     Write HTML file named filename containing figure.


### PR DESCRIPTION
This PR fixes two non-substantive problems:

(1) a coding-style error generated by the `make cstest` command, which was introduced by the recent merge of PR #2882.  Here is that error:
```
(taxcalc-dev) Tax-Calculator% make cstest
./taxcalc/utils.py:1318:1: E303 too many blank lines (3)
```

(2) a malformed CLI tool error message, which probably dates back years ago to when Tax-Calculator was revised to use ParamTools instead of its own parameters class.   Here is an example of a malformed error message:
```
(taxcalc-dev) Tax-Calculator% tc --version
Tax-Calculator 4.5.0 on Python 3.12
(taxcalc-dev) Tax-Calculator% cat ref.json
{"ACTC_c": {"2033": 1100}}
(taxcalc-dev) Tax-Calculator% tc cps.csv 2035 --reform ref.json
ACTC_c[year=2033] 1100.0 > max 1000.0 CTC_c[year=2033]
ACTC_c[year=2034] 1100.0 > max 1000.0 CTC_c[year=2034]
ACTC_c[year=2035] 1100.0 > max 1000.0 CTC_c[year=2035]USAGE: tc --help
```
The error message returned to the `taxcalc/cli/tc.py` code did not end with a newline character, so `USAGE: tc --help` was not printed on its own line.
