### PR TITLE
Avoid marshmallow 4.0 version; revise docs wrt no Python 3.9 support

### DIFF
--- a/docs/usage/starting.md
+++ b/docs/usage/starting.md
@@ -2,7 +2,7 @@ Getting started
 ===============
 
 Tax-Calculator packages are available for Windows, Mac, and Linux computers
-that have the free Anaconda Python 3.9, 3.10, 3.11, or 3.12 distribution
+that have the free Anaconda Python 3.10, 3.11, or 3.12 distribution
 installed.  You can use Tax-Calculator without doing any Python programming,
 but the Anaconda distribution is required for Tax-Calculator to run.
 Take the following four steps to get started.

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,5 @@ dependencies:
 - pip
 - pip:
     - jupyter-book
-    - "paramtools>=0.19.0"
+    - "marshmallow>=3.22, <4.0"  # TODO: drop this after ParamTools is fixed
+    - "paramtools>=0.19.0"       # TODO: bump version after ParamTools is fixed

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -68,6 +68,7 @@ def test_for_consistency(tests_path):
         'coverage',
         "pip",
         "jupyter-book",
+        "marshmallow>=3.22, <4.0",  # TODO: drop this after ParamTools is fixed
         "setuptools"
     ])
     # read conda.recipe/meta.yaml requirements


### PR DESCRIPTION
See [ParamTools issue #144](https://github.com/PSLmodels/ParamTools/issues/144).
Also, incorporates documentation change in Tax-Calculator PR #2880.