### PR TITLE
Add CLI action messages and --silent option to suppress the messages

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -126,10 +126,14 @@ class Calculator():
                 )
         else:
             if verbose:
-                print('Read input data that were not extrapolated in any way')
-        if verbose and self.__records.IGNORED_VARS:
-            print('Input data include the following unused ' +
-                  'variables that will be ignored:')
+                print(  # pragma: no cover
+                    'Read input data that were not extrapolated in any way'
+                )
+        if verbose and self.__records.IGNORED_VARS:  # pragma: no cover
+            print(
+                'Input data include the following unused '
+                'variables that will be ignored:'
+            )
             for var in self.__records.IGNORED_VARS:
                 print(f'  {var}')
         assert self.__policy.current_year == self.__records.current_year

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -113,29 +113,25 @@ class Calculator():
             raise ValueError('consumption must be None or Consumption object')
         if self.__consumption.current_year < self.__policy.current_year:
             self.__consumption.set_year(self.__policy.current_year)
-        if verbose:
-            if self.__records.IGNORED_VARS:
-                print('Your data include the following unused ' +
-                      'variables that will be ignored:')
-                for var in self.__records.IGNORED_VARS:
-                    print('  ' +
-                          var)
         current_year_is_data_year = (
             self.__records.current_year == self.__records.data_year)
         if sync_years and current_year_is_data_year:
-            if verbose:
-                print('You loaded data for ' +
-                      str(self.__records.data_year) + '.')
             while self.__records.current_year < self.__policy.current_year:
                 self.__records.increment_year()
             if verbose:
-                print('Tax-Calculator startup automatically ' +
-                      'extrapolated your data to ' +
-                      str(self.__records.current_year) + '.')
+                print(
+                    f'Read input data for {self.__records.data_year}; '
+                    'input data were extrapolated to '
+                    f'{self.__records.current_year}'
+                )
         else:
             if verbose:
-                print('Tax-Calculator startup did not ' +
-                      'extrapolate your data.')
+                print('Read input data that were not extrapolated in any way')
+        if verbose and self.__records.IGNORED_VARS:
+            print('Input data include the following unused ' +
+                  'variables that will be ignored:')
+            for var in self.__records.IGNORED_VARS:
+                print(f'  {var}')
         assert self.__policy.current_year == self.__records.current_year
         assert self.__policy.current_year == self.__consumption.current_year
         self.__stored_records = None

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -35,7 +35,7 @@ def cli_tc_main():
         ('          '
          '[--dump] [--dvars DVARS] [--sqldb] [--outdir OUTDIR]\n'),
         ('          '
-         '[--test] [--version]'))
+         '[--silent] [--test] [--version]'))
     parser = argparse.ArgumentParser(
         prog='',
         usage=usage_str,
@@ -127,6 +127,11 @@ def cli_tc_main():
                               'No --outdir implies output files are written '
                               'in the current directory.'),
                         default=None)
+    parser.add_argument('--silent',
+                        help=('optional flag that suppresses messages about '
+                              'input and output actions.'),
+                        default=False,
+                        action="store_true")
     parser.add_argument('--test',
                         help=('optional flag that conducts installation '
                               'test, writes test result to stdout, '
@@ -167,7 +172,7 @@ def cli_tc_main():
     tcio = tc.TaxCalcIO(input_data=inputfn, tax_year=taxyear,
                         baseline=args.baseline,
                         reform=args.reform, assump=args.assump,
-                        outdir=args.outdir)
+                        silent=args.silent, outdir=args.outdir)
     if tcio.errmsg:
         if tcio.errmsg.endswith('\n'):
             sys.stderr.write(tcio.errmsg)

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -25,13 +25,15 @@ def cli_tc_main():
     # pylint: disable=too-many-statements,too-many-branches
     # pylint: disable=too-many-return-statements,too-many-locals
 
+    start_time = time.time()
+
     # parse command-line arguments:
     usage_str = 'tc INPUT TAXYEAR {}{}{}{}{}'.format(
         '[--help]\n',
         ('          '
          '[--baseline BASELINE] [--reform REFORM] [--assump  ASSUMP]\n'),
         ('          '
-         '[--exact] [--tables] [--graphs] [--timings]\n'),
+         '[--exact] [--tables] [--graphs]\n'),
         ('          '
          '[--dump] [--dvars DVARS] [--sqldb] [--outdir OUTDIR]\n'),
         ('          '
@@ -88,11 +90,6 @@ def cli_tc_main():
     parser.add_argument('--graphs',
                         help=('optional flag that causes graphs to be written '
                               'to HTML files for viewing in browser.'),
-                        default=False,
-                        action="store_true")
-    parser.add_argument('--timings',
-                        help=('optional flag that causes execution times to '
-                              'be written to stdout.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--dump',
@@ -185,16 +182,11 @@ def cli_tc_main():
         inputfn.endswith('cps.csv') or
         inputfn.endswith('tmd.csv')
     )
-    if args.timings:
-        stime = time.time()
     tcio.init(input_data=inputfn, tax_year=taxyear,
               baseline=args.baseline,
               reform=args.reform, assump=args.assump,
               aging_input_data=aging,
               exact_calculations=args.exact)
-    if args.timings:
-        xtime = time.time() - stime
-        sys.stdout.write(f'TIMINGS: init time = {xtime:.2f} secs\n')
     if tcio.errmsg:
         if tcio.errmsg.endswith('\n'):
             sys.stderr.write(tcio.errmsg)
@@ -221,21 +213,20 @@ def cli_tc_main():
             sys.stderr.write('USAGE: tc --help\n')
             return 1
     # conduct tax analysis
-    if args.timings:
-        stime = time.time()
     tcio.analyze(writing_output_file=True,
                  output_tables=args.tables,
                  output_graphs=args.graphs,
                  dump_varset=dumpvar_set,
                  output_dump=args.dump,
                  output_sqldb=args.sqldb)
-    if args.timings:
-        xtime = time.time() - stime
-        sys.stdout.write(f'TIMINGS: calc time = {xtime:.2f} secs\n')
     # compare test output with expected test output if --test option specified
     if args.test:
         retcode = _compare_test_output_files()
         return retcode
+    if not args.silent:
+        print(  # pragma: no cover
+            f'Execution time is {(time.time() - start_time):.1f} seconds'
+        )
     return 0
 # end of cli_tc_main function code
 

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -54,6 +54,9 @@ class TaxCalcIO():
         None implies economic assumptions are standard assumptions,
         or string is name of optional ASSUMP file.
 
+    silent: boolean
+        whether or not to suppress action messages.
+
     outdir: None or string
         None implies output files written to current directory,
         or string is name of optional output directory
@@ -65,9 +68,10 @@ class TaxCalcIO():
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, input_data, tax_year, baseline, reform, assump,
-                 outdir=None):
+                 silent=True, outdir=None):
         # pylint: disable=too-many-arguments,too-many-positional-arguments
         # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+        self.silent = silent
         self.gf_reform = None
         self.errmsg = ''
         # check name and existence of INPUT file
@@ -404,7 +408,7 @@ class TaxCalcIO():
             recs_base = copy.deepcopy(recs)
         # create Calculator objects
         self.calc = Calculator(policy=pol, records=recs,
-                               verbose=True,
+                               verbose=(not self.silent),
                                consumption=con,
                                sync_years=aging_input_data)
         self.calc_base = Calculator(policy=base, records=recs_base,
@@ -496,11 +500,11 @@ class TaxCalcIO():
         # pylint: disable=too-many-arguments,too-many-positional-arguments
         # pylint: disable=too-many-branches,too-many-locals
         if self.puf_input_data and self.calc.reform_warnings:
-            warn = 'PARAMETER VALUE WARNING(S):  {}\n{}{}'  # pragma: no cover
             print(  # pragma: no cover
-                warn.format('(read documentation for each parameter)',
-                            self.calc.reform_warnings,
-                            'CONTINUING WITH CALCULATIONS...')
+                'PARAMETER VALUE WARNING(S):  '
+                '(read documentation for each parameter)\n'
+                f'{self.calc.reform_warnings}'
+                'CONTINUING WITH CALCULATIONS...'
             )
         calc_base_calculated = False
         self.calc.calc_all()
@@ -577,6 +581,10 @@ class TaxCalcIO():
                          index=False, float_format='%.2f')
         del outdf
         gc.collect()
+        if not self.silent:
+            print(  # pragma: no cover
+                f'Write tax-unit output to file {self._output_filename}'
+            )
 
     def write_doc_file(self):
         """
@@ -593,6 +601,10 @@ class TaxCalcIO():
         doc_fname = self._output_filename.replace('.csv', '-doc.text')
         with open(doc_fname, 'w', encoding='utf-8') as dfile:
             dfile.write(doc)
+        if not self.silent:
+            print(  # pragma: no cover
+                f'Write reform documentation to file {doc_fname}'
+            )
 
     def write_sqldb_file(self, dump_varset, mtr_paytax, mtr_inctax,
                          mtr_paytax_base, mtr_inctax_base):
@@ -617,6 +629,10 @@ class TaxCalcIO():
         dbcon.close()
         del outdf
         gc.collect()
+        if not self.silent:
+            print(  # pragma: no cover
+                f'Write tax-unit output to sqlite3 database file {db_fname}'
+            )
 
     def write_tables_file(self):
         """
@@ -656,6 +672,10 @@ class TaxCalcIO():
         del distdf
         del diffdf
         gc.collect()
+        if not self.silent:
+            print(  # pragma: no cover
+                f'Write tabular output to file {tab_fname}'
+            )
 
     @staticmethod
     def write_decile_table(dfx, tfile, tkind='Totals'):
@@ -773,6 +793,12 @@ class TaxCalcIO():
         if fig:
             del fig
             gc.collect()
+        if not self.silent:
+            print(  # pragma: no cover
+                f'Write graphical output to file {pch_fname}\n'
+                f'Write graphical output to file {atr_fname}\n'
+                f'Write graphical output to file {mtr_fname}'
+            )
 
     @staticmethod
     def write_empty_graph_file(fname, title, reason):

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -808,10 +808,10 @@ def test_itemded_component_amounts(year, cvname, hcname, puf_fullsample):
     policy2.implement_reform(reform2)
     assert not policy2.parameter_errors
     # compute tax liability in specified year
-    calc1 = Calculator(policy=policy1, records=recs, verbose=False)
+    calc1 = Calculator(policy=policy1, records=recs, verbose=True)
     calc1.advance_to_year(year)
     calc1.calc_all()
-    calc2 = Calculator(policy=policy2, records=recs, verbose=False)
+    calc2 = Calculator(policy=policy2, records=recs, verbose=True)
     calc2.advance_to_year(year)
     calc2.calc_all()
     # confirm that nobody is taking the standard deduction

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -316,7 +316,8 @@ def test_creation_with_aging(reformfile0):
                      tax_year=taxyear,
                      baseline=None,
                      reform=reformfile0.name,
-                     assump=None)
+                     assump=None,
+                     silent=False)
     assert not tcio.errmsg
     tcio.init(input_data=pd.read_csv(StringIO(RAWINPUT)),
               tax_year=taxyear,


### PR DESCRIPTION
This PR adds messages to make it more clear what the `tc` CLI tool is doing (that is, how it is handling input data and what output files it is writing).  These messages are written by default, but they can be suppressed using the new `--silent` option.

This is what typical output looks like after these changes have been made:
```
% tc puf.csv 2025 --exact --tables --graphs
Read input data for 2011; input data were extrapolated to 2025
Write tax-unit output to file puf-25-#-#-#.csv
Write reform documentation to file puf-25-#-#-#-doc.text
Write tabular output to file puf-25-#-#-#-tab.text
Write graphical output to file puf-25-#-#-#-pch.html
Write graphical output to file puf-25-#-#-#-atr.html
Write graphical output to file puf-25-#-#-#-mtr.html
Execution time is 44.1 seconds
```
