### PR TITLE
Add CLI --params option and associated logic

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -2059,7 +2059,7 @@ def AMT(e07300, dwks13, standard, f6251, c00100, c18300, taxbc,
     e62900: float
         Alternative Minimum Tax foreign tax credit from Form 6251
     e00700: float
-        Schedule C business net profit/loss for filing unit
+        Taxable refunds of state and local income taxes
     dwks10: float
         Sum of dwks6 + dwks9
     age_head: int

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -30,14 +30,24 @@ def cli_tc_main():
     # parse command-line arguments:
     usage_str = 'tc INPUT TAXYEAR {}{}{}{}{}'.format(
         '[--help]\n',
-        ('          '
-         '[--baseline BASELINE] [--reform REFORM] [--assump  ASSUMP]\n'),
-        ('          '
-         '[--exact] [--tables] [--graphs]\n'),
-        ('          '
-         '[--dump] [--dvars DVARS] [--sqldb] [--outdir OUTDIR]\n'),
-        ('          '
-         '[--silent] [--test] [--version]'))
+        (
+            '          '
+            '[--baseline BASELINE] [--reform REFORM] [--assump  ASSUMP] '
+            '[--exact]\n'
+        ),
+        (
+            '          '
+            '[--params] [--tables] [--graphs]\n'
+        ),
+        (
+            '          '
+            '[--dump] [--dvars DVARS] [--sqldb] [--outdir OUTDIR]\n'
+        ),
+        (
+            '          '
+            '[--silent] [--test] [--version]'
+        )
+    )
     parser = argparse.ArgumentParser(
         prog='',
         usage=usage_str,
@@ -80,6 +90,12 @@ def cli_tc_main():
                         help=('optional flag that suppresses the smoothing of '
                               '"stair-step" provisions in the tax law that '
                               'complicate marginal-tax-rate calculations.'),
+                        default=False,
+                        action="store_true")
+    parser.add_argument('--params',
+                        help=('optional flag that causes policy parameter '
+                              'values for baseline and reform to be written '
+                              'to separate text files.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--tables',
@@ -214,6 +230,7 @@ def cli_tc_main():
             return 1
     # conduct tax analysis
     tcio.analyze(writing_output_file=True,
+                 output_params=args.params,
                  output_tables=args.tables,
                  output_graphs=args.graphs,
                  dump_varset=dumpvar_set,

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -220,13 +220,17 @@ class TaxCalcIO():
             delete_old_files = False
         if delete_old_files:
             delete_file(self._output_filename)
-            delete_file(self._output_filename.replace('.csv', '.db'))
-            delete_file(self._output_filename.replace('.csv', '-params.bas'))
-            delete_file(self._output_filename.replace('.csv', '-params.ref'))
-            delete_file(self._output_filename.replace('.csv', '-tables.text'))
-            delete_file(self._output_filename.replace('.csv', '-atr.html'))
-            delete_file(self._output_filename.replace('.csv', '-mtr.html'))
-            delete_file(self._output_filename.replace('.csv', '-pch.html'))
+            extensions = [
+                '.db',
+                '-params.bas',
+                '-params.ref',
+                '-tables.text',
+                '-atr.html',
+                '-mtr.html',
+                '-pch.html',
+            ]
+            for ext in extensions:
+                delete_file(self._output_filename.replace('.csv', ext))
         # initialize variables whose values are set in init method
         self.calc = None
         self.calc_base = None
@@ -476,8 +480,8 @@ class TaxCalcIO():
            whether or not to generate and write output file
 
         output_params: boolean
-           whether or not to generate and write reform-vs-baseline
-           policy parameter differences to a text file
+           whether or not to write baseline and reform policy parameter
+           values to separate text files
 
         output_tables: boolean
            whether or not to generate and write distributional tables

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -545,7 +545,7 @@ class TaxCalcIO():
                 dump_varset, mtr_paytax, mtr_inctax,
                 mtr_paytax_base, mtr_inctax_base
             )
-        # optionally write --params output to text file
+        # optionally write --params output to text files
         if output_params:
             self.write_policy_params_files()
         # optionally write --tables output to text file
@@ -601,7 +601,7 @@ class TaxCalcIO():
 
     def write_policy_params_files(self):
         """
-        Write policy parameter values for baseline and reform
+        Write baseline and reform policy parameter values to separate files.
         """
         param_names = Policy.parameter_list()
         fname = self._output_filename.replace('.csv', '-params.bas')

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -456,39 +456,39 @@ def test_output_options(reformfile1, assumpfile1):
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
         assert False, 'TaxCalcIO.analyze(partial_dump_output) failed'
-    # if tries were successful, remove doc file and output file
-    docfilepath = outfilepath.replace('.csv', '-doc.text')
-    if os.path.isfile(docfilepath):
-        os.remove(docfilepath)
+    # if tries were successful, remove output file
     if os.path.isfile(outfilepath):
         os.remove(outfilepath)
 
 
-def test_write_doc_file(reformfile1, assumpfile1):
+def test_write_policy_param_files(reformfile1):
     """
-    Test write_doc_file with compound reform.
+    Test write_policy_params_diff_file with compound reform.
     """
     taxyear = 2021
     compound_reform = f'{reformfile1.name}+{reformfile1.name}'
-    tcio = TaxCalcIO(input_data=pd.read_csv(StringIO(RAWINPUT)),
-                     tax_year=taxyear,
-                     baseline=None,
-                     reform=compound_reform,
-                     assump=assumpfile1.name)
+    tcio = TaxCalcIO(
+        input_data=pd.read_csv(StringIO(RAWINPUT)),
+        tax_year=taxyear,
+        baseline=None,
+        reform=compound_reform,
+        assump=None,
+    )
     assert not tcio.errmsg
     tcio.init(input_data=pd.read_csv(StringIO(RAWINPUT)),
               tax_year=taxyear,
               baseline=None,
               reform=compound_reform,
-              assump=assumpfile1.name,
+              assump=None,
               aging_input_data=False,
               exact_calculations=False)
     assert not tcio.errmsg
-    tcio.write_doc_file()
+    tcio.write_policy_params_files()
     outfilepath = tcio.output_filepath()
-    docfilepath = outfilepath.replace('.csv', '-doc.text')
-    if os.path.isfile(docfilepath):
-        os.remove(docfilepath)
+    for ext in ['-params.bas', '-params.ref']:
+        filepath = outfilepath.replace('.csv', ext)
+        if os.path.isfile(filepath):
+            os.remove(filepath)
 
 
 def test_sqldb_option(reformfile1, assumpfile1):
@@ -562,7 +562,7 @@ def test_no_tables_or_graphs(reformfile1):
                  output_graphs=True)
     # delete tables and graph files
     output_filename = tcio.output_filepath()
-    fname = output_filename.replace('.csv', '-tab.text')
+    fname = output_filename.replace('.csv', '-tables.text')
     if os.path.isfile(fname):
         os.remove(fname)
     fname = output_filename.replace('.csv', '-atr.html')
@@ -608,7 +608,7 @@ def test_tables(reformfile1):
     tcio.analyze(writing_output_file=False, output_tables=True)
     # delete tables file
     output_filename = tcio.output_filepath()
-    fname = output_filename.replace('.csv', '-tab.text')
+    fname = output_filename.replace('.csv', '-tables.text')
     if os.path.isfile(fname):
         os.remove(fname)
 

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -463,7 +463,7 @@ def test_output_options(reformfile1, assumpfile1):
 
 def test_write_policy_param_files(reformfile1):
     """
-    Test write_policy_params_diff_file with compound reform.
+    Test write_policy_params_files with compound reform.
     """
     taxyear = 2021
     compound_reform = f'{reformfile1.name}+{reformfile1.name}'

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -529,8 +529,8 @@ def test_sqldb_option(reformfile1, assumpfile1):
 
 def test_no_tables_or_graphs(reformfile1):
     """
-    Test TaxCalcIO with output_tables=True and output_graphs=True but
-    INPUT has zero weights.
+    Test TaxCalcIO with output_params=True and output_tables=True and
+    output_graphs=True but INPUT has zero weights.
     """
     # create input sample that cannot output tables or graphs
     nobs = 10
@@ -556,24 +556,25 @@ def test_no_tables_or_graphs(reformfile1):
               aging_input_data=False,
               exact_calculations=False)
     assert not tcio.errmsg
-    # create TaxCalcIO tables file
+    # create several TaxCalcIO output files
     tcio.analyze(writing_output_file=False,
+                 output_params=True,
                  output_tables=True,
                  output_graphs=True)
     # delete tables and graph files
     output_filename = tcio.output_filepath()
-    fname = output_filename.replace('.csv', '-tables.text')
-    if os.path.isfile(fname):
-        os.remove(fname)
-    fname = output_filename.replace('.csv', '-atr.html')
-    if os.path.isfile(fname):
-        os.remove(fname)
-    fname = output_filename.replace('.csv', '-mtr.html')
-    if os.path.isfile(fname):
-        os.remove(fname)
-    fname = output_filename.replace('.csv', '-pch.html')
-    if os.path.isfile(fname):
-        os.remove(fname)
+    extensions = [
+        '-params.bas',
+        '-params.ref',
+        '-tables.text',
+        '-atr.html',
+        '-mtr.html',
+        '-pch.html',
+    ]
+    for ext in extensions:
+        fname = output_filename.replace('.csv', ext)
+        if os.path.isfile(fname):
+            os.remove(fname)
 
 
 def test_tables(reformfile1):


### PR DESCRIPTION
The `tc` CLI tool `--params` option writes all baseline policy parameter values to one file and all reform policy parameter values to another file, so that they can be compared using any diff tool.

Also, fix AMT documentation error reported in issue #2887.
