### PR TITLE
Release Tax-Calculator 4.6.0 version

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -4,6 +4,28 @@ Go [here](https://github.com/PSLmodels/Tax-Calculator/pulls?q=is%3Apr+is%3Aclose
 for a complete commit history.
 
 
+2025-04-30 Release 4.6.0
+------------------------
+(last merged pull request is
+[#2893](https://github.com/PSLmodels/Tax-Calculator/pull/2893))
+
+**This is an enhancement and bug-fix release.**
+
+**API Changes**
+
+**New Features**
+- Several enhancements to Tax-Calculator CLI program, `tc`
+[PRs [#2886](https://github.com/PSLmodels/Tax-Calculator/pull/2886), [#2888](https://github.com/PSLmodels/Tax-Calculator/pull/2888), [#2889](https://github.com/PSLmodels/Tax-Calculator/pull/2889), [#2890](https://github.com/PSLmodels/Tax-Calculator/pull/2890), [#2891](https://github.com/PSLmodels/Tax-Calculator/pull/2891), and [#2893](https://github.com/PSLmodels/Tax-Calculator/pull/2893) by Martin Holmer]
+
+**Bug Fixes**
+- Update required `bokeh` version
+[[#2882](https://github.com/PSLmodels/Tax-Calculator/pull/2882) by Bodi Yang]
+- Make ACTC_c parameter be inflation indexed in the TCJA-extension reform
+[[#2883](https://github.com/PSLmodels/Tax-Calculator/pull/2883) by Martin Holmer]
+- Avoid `marshmallow` version 4.0.0 until `paramtools` is fixed
+[[#2885](https://github.com/PSLmodels/Tax-Calculator/pull/2885) by Martin Holmer]
+
+
 2025-03-11 Release 4.5.0
 ------------------------
 (last merged pull request is

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with open("README.md", "r", encoding="utf-8") as f:
     longdesc = f.read()
 
-VERSION = "4.5.0"
+VERSION = "4.6.0"
 
 config = {
     "description": "Tax-Calculator",

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -14,6 +14,6 @@ from taxcalc.taxcalcio import *
 from taxcalc.utils import *
 from taxcalc.cli import *
 
-__version__ = '4.5.0'
+__version__ = '4.6.0'
 __min_python3_version__ = 10
 __max_python3_version__ = 12


### PR DESCRIPTION
@jdebacker,  Could you merge and generate `taxcalc` packages for PyPi **and** conda-forge?