### PR TITLE
Add ability for CLI to handle --baseline compound reforms just as the --reform option does

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,17 +5,14 @@ Tax-Calculator
 
 Tax-Calculator is an open-source microsimulation model for static analysis of
 USA federal income and payroll taxes.
-You can install it with [Anaconda](https://www.anaconda.com/products/individual)
-via:
-
-```
-conda update taxcalc
-```
-
-or with [PyPI](https://pypi.org/project/taxcalc/) via:
-
+You can install it with [PyPI](https://pypi.org/project/taxcalc/) via:
 ```
 pip install taxcalc
+```
+or with [Anaconda](https://www.anaconda.com/products/individual)
+via:
+```
+conda install conda-forge::taxcalc
 ```
 
 When using sample data that represent the USA population,
@@ -60,15 +57,12 @@ cross-model validation work with NBER's TAXSIM-35 model is described
 {doc}`4.6.0 (2025-04-30) <about/releases>`
 
 If you are already using Tax-Calculator, upgrade using the following command:
-
-```
-conda update conda-forge::taxcalc
-```
-
-or
-
 ```
 pip install --upgrade taxcalc
+```
+or
+```
+conda update conda-forge::taxcalc
 ```
 
 If you're a new user, read {doc}`usage/starting`.

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -66,14 +66,14 @@ def cli_tc_main():
     parser.add_argument('--baseline',
                         help=('BASELINE is name of optional JSON reform file. '
                               'A compound reform can be specified using 2+ '
-                              'file names separated by a plus (+) character. '
+                              'file names separated by plus (+) character(s). '
                               'No --baseline implies baseline policy is '
                               'current-law policy.'),
                         default=None)
     parser.add_argument('--reform',
                         help=('REFORM is name of optional JSON reform file. '
                               'A compound reform can be specified using 2+ '
-                              'file names separated by a plus (+) character. '
+                              'file names separated by plus (+) character(s). '
                               'No --reform implies reform policy is '
                               'current-law policy).'),
                         default=None)

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -1,6 +1,6 @@
 """
 Command-line interface (CLI) to Tax-Calculator,
-which can be accessed as 'tc' from an installed taxcalc conda package.
+which can be accessed as 'tc' from an installed taxcalc package.
 """
 # CODING-STYLE CHECKS:
 # pycodestyle tc.py
@@ -65,12 +65,14 @@ def cli_tc_main():
                         default=0)
     parser.add_argument('--baseline',
                         help=('BASELINE is name of optional JSON reform file. '
+                              'A compound reform can be specified using 2+ '
+                              'file names separated by a plus (+) character. '
                               'No --baseline implies baseline policy is '
                               'current-law policy.'),
                         default=None)
     parser.add_argument('--reform',
                         help=('REFORM is name of optional JSON reform file. '
-                              'A compound reform can be specified using two '
+                              'A compound reform can be specified using 2+ '
                               'file names separated by a plus (+) character. '
                               'No --reform implies reform policy is '
                               'current-law policy).'),

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -484,14 +484,14 @@ def test_write_policy_param_files(reformfile1):
     tcio = TaxCalcIO(
         input_data=pd.read_csv(StringIO(RAWINPUT)),
         tax_year=taxyear,
-        baseline=None,
+        baseline=compound_reform,
         reform=compound_reform,
         assump=None,
     )
     assert not tcio.errmsg
     tcio.init(input_data=pd.read_csv(StringIO(RAWINPUT)),
               tax_year=taxyear,
-              baseline=None,
+              baseline=compound_reform,
               reform=compound_reform,
               assump=None,
               aging_input_data=False,


### PR DESCRIPTION
Adding this capability to the `tc` CLI tool makes the `--baseline` option work exactly the same as the `--reform` option.   

This is useful in many situations such as when you want to analyze different options for paying for revenue-reducing adjustments to the extend-TCJA reform `ext.json`.  So, for example, if `adj.json` raises the SALT-cap amounts, and `pay1.json` is your first thought about how to pay for that adjustment, you can now use syntax like this: 
```
tc ../tmd.csv 2026 --baseline ext.json+adj.json --reform ext.json+adj.json+pay1.json --params --tables --dumpdb
```
Such a run shows the aggregate and distributional impacts of your first thought about how to pay for the higher SALT caps.

If you want to see the joint aggregate and distributional impacts of the higher SALT caps **and** your first thought about how to pay for the higher SALT caps, you can execute a run like this:
```
tc ../tmd.csv 2026 --baseline ext.json --reform ext.json+adj.json+pay1.json --params --tables --dumpdb
```
