### PR TITLE
Require `paramtools` 0.20.0 or higher

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - "numpy>=1.26"
     - "pandas>=2.2"
     - "bokeh>=3.7"
-    - "paramtools>=0.19.0"
+    - "paramtools>=0.20.0"
     - numba
     - curl
     - openpyxl
@@ -23,7 +23,7 @@ requirements:
     - "numpy>=1.26"
     - "pandas>=2.2"
     - "bokeh>=3.7"
-    - "paramtools>=0.19.0"
+    - "paramtools>=0.20.0"
     - numba
     - curl
     - openpyxl

--- a/environment.yml
+++ b/environment.yml
@@ -19,5 +19,4 @@ dependencies:
 - pip
 - pip:
     - jupyter-book
-    - "marshmallow>=3.22, <4.0"  # TODO: drop this after ParamTools is fixed
-    - "paramtools>=0.19.0"       # TODO: bump version after ParamTools is fixed
+    - "paramtools>=0.20.0"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ config = {
         "pandas>=2.2",
         "bokeh>=2.4",
         "numba",
-        "paramtools>=0.19.0",
+        "paramtools>=0.20.0",
     ],
     "classifiers": [
         "Development Status :: 4 - Beta",

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -68,7 +68,6 @@ def test_for_consistency(tests_path):
         'coverage',
         "pip",
         "jupyter-book",
-        "marshmallow>=3.22, <4.0",  # TODO: drop this after ParamTools is fixed
         "setuptools"
     ])
     # read conda.recipe/meta.yaml requirements


### PR DESCRIPTION
This pull request should pass all the tests on GitHub as soon as [ParamTools PR #146](https://github.com/PSLmodels/ParamTools/pull/146) is merged and a new `paramtools` package is made available.  

This PR resolves the problem reported in issue #2892.