### PR TITLE
Release Tax-Calculator 4.6.2 version

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -4,6 +4,24 @@ Go [here](https://github.com/PSLmodels/Tax-Calculator/pulls?q=is%3Apr+is%3Aclose
 for a complete commit history.
 
 
+2025-05-16 Release 4.6.2
+------------------------
+(last merged pull request is
+[#2905](https://github.com/PSLmodels/Tax-Calculator/pull/2905))
+
+**This is a bug-fix release.**
+
+**API Changes**
+
+**New Features**
+
+**Bug Fixes**
+- Work around multiple-indexing-change limitations in `parameters.py` code
+[[#2904](https://github.com/PSLmodels/Tax-Calculator/pull/2904) by Martin Holmer]
+- Require `paramtools` 0.20.0 that works with the current `marshmallow` 4.0.0
+[[#2905](https://github.com/PSLmodels/Tax-Calculator/pull/2905) by Martin Holmer]
+
+
 2025-05-09 Release 4.6.1
 ------------------------
 (last merged pull request is

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ cross-model validation work with NBER's TAXSIM-35 model is described
 
 ## Latest release
 
-{doc}`4.6.1 (2025-05-09) <about/releases>`
+{doc}`4.6.2 (2025-05-16) <about/releases>`
 
 If you are already using Tax-Calculator, upgrade using the following command:
 ```

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with open("README.md", "r", encoding="utf-8") as f:
     longdesc = f.read()
 
-VERSION = "4.6.1"
+VERSION = "4.6.2"
 
 config = {
     "description": "Tax-Calculator",

--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: taxcalc
-Version: 4.6.1
+Version: 4.6.2
 Summary: Tax-Calculator
 Home-page: https://github.com/PSLmodels/Tax-Calculator
 Download-URL: https://github.com/PSLmodels/Tax-Calculator
@@ -22,7 +22,7 @@ Requires-Dist: numpy>=1.26
 Requires-Dist: pandas>=2.2
 Requires-Dist: bokeh>=2.4
 Requires-Dist: numba
-Requires-Dist: paramtools>=0.19.0
+Requires-Dist: paramtools>=0.20.0
 Dynamic: classifier
 Dynamic: description
 Dynamic: description-content-type

--- a/taxcalc.egg-info/requires.txt
+++ b/taxcalc.egg-info/requires.txt
@@ -2,4 +2,4 @@ numpy>=1.26
 pandas>=2.2
 bokeh>=2.4
 numba
-paramtools>=0.19.0
+paramtools>=0.20.0

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -14,6 +14,6 @@ from taxcalc.taxcalcio import *
 from taxcalc.utils import *
 from taxcalc.cli import *
 
-__version__ = '4.6.1'
+__version__ = '4.6.2'
 __min_python3_version__ = 10
 __max_python3_version__ = 12


### PR DESCRIPTION
@jdebacker, Could you review and merge and then generate `taxcalc` packages for PyPi and conda-forge? Thanks.