### PR TITLE
Add option to simplify CLI output file names

### DIFF
--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -43,7 +43,7 @@ def cli_tc_main():
         ),
         (
             '          '
-            '[--silent] [--test] [--version] [--usage]'
+            '[--runid N] [--silent] [--test] [--version] [--usage]'
         )
     )
     parser = argparse.ArgumentParser(
@@ -75,20 +75,20 @@ def cli_tc_main():
     parser.add_argument('--baseline',
                         help=('BASELINE is name of optional JSON reform file. '
                               'A compound reform can be specified using 2+ '
-                              'file names separated by plus (+) character(s). '
+                              'file names connected by plus (+) character(s). '
                               'No --baseline implies baseline policy is '
                               'current-law policy.'),
                         default=None)
     parser.add_argument('--reform',
                         help=('REFORM is name of optional JSON reform file. '
                               'A compound reform can be specified using 2+ '
-                              'file names separated by plus (+) character(s). '
+                              'file names connected by plus (+) character(s). '
                               'No --reform implies reform policy is '
                               'current-law policy).'),
                         default=None)
     parser.add_argument('--assump',
                         help=('ASSUMP is name of optional JSON economic '
-                              'assumptions file.  No --assump implies use '
+                              'assumptions file. No --assump implies use '
                               'of no customized assumptions.'),
                         default=None)
     parser.add_argument('--exact',
@@ -125,12 +125,19 @@ def cli_tc_main():
     parser.add_argument('--dumpvars',
                         help=('DUMPVARS is name of optional file containing a '
                               'space-delimited list of variables to include '
-                              'in the dump database.  No --dumpvars '
-                              'implies a minimal set of variables.  Valid '
-                              'variable names include all variables in the '
+                              'in the dump database. No --dumpvars implies '
+                              'a minimal set of variables.  Valid variable '
+                              'names include all variables in the '
                               'records_variables.json file plus mtr_itax and '
                               'mtr_ptax (MTRs wrt taxpayer earnings).'),
                         default=None)
+    parser.add_argument('--runid', metavar='N',
+                        help=('N is a positive integer run id that is used '
+                              'to construct simpler output file names. '
+                              'No --runid implies legacy output file names '
+                              'are used.'),
+                        type=int,
+                        default=0)
     parser.add_argument('--silent',
                         help=('optional flag that suppresses messages about '
                               'input and output actions.'),
@@ -224,6 +231,11 @@ def cli_tc_main():
             sys.stderr.write(msg)
             sys.stderr.write('USAGE: tc --help\n')
             return 1
+    if args.runid < 0:
+        msg = 'ERROR: --runid parameter N is less than zero\n'
+        sys.stderr.write(msg)
+        sys.stderr.write('USAGE: tc --help\n')
+        return 1
     # do calculations for taxyear
     # ... initialize TaxCalcIO object for taxyear
     tcio = tc.TaxCalcIO(
@@ -232,6 +244,7 @@ def cli_tc_main():
         baseline=args.baseline,
         reform=args.reform,
         assump=args.assump,
+        runid=args.runid,
         silent=args.silent,
     )
     if tcio.errmsg:

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -54,6 +54,9 @@ class TaxCalcIO():
         None implies economic assumptions are standard assumptions,
         or string is name of optional ASSUMP file.
 
+    runid: int
+        run id value to use for simpler output file names
+
     silent: boolean
         whether or not to suppress action messages.
 
@@ -64,7 +67,7 @@ class TaxCalcIO():
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, input_data, tax_year, baseline, reform, assump,
-                 silent=True):
+                 runid=0, silent=True):
         # pylint: disable=too-many-arguments,too-many-positional-arguments
         # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         self.silent = silent
@@ -225,6 +228,9 @@ class TaxCalcIO():
             self.errmsg += f'ERROR: {msg}\n'
         # create OUTPUT file name and delete any existing output files
         self.output_filename = f'{inp}{bas}{ref}{asm}.xxx'
+        self.runid = runid
+        if runid > 0:
+            self.output_filename = f'run{runid}-{str(tax_year)[2:]}.xxx'
         self.delete_output_files()
         # initialize variables whose values are set in init method
         self.calc_ref = None
@@ -478,7 +484,12 @@ class TaxCalcIO():
         """
         # update self.output_filename and delete output files
         parts = self.output_filename.split('-')
-        parts[1] = str(year)[2:]
+        if self.runid == 0:  # if using legacy output file names
+            parts[1] = str(year)[2:]
+        else:  # if using simpler output file names (runN-YY.xxx)
+            subparts = parts[1].split('.')
+            subparts[0] = str(year)[2:]
+            parts[1] = '.'.join(subparts)
         self.output_filename = '-'.join(parts)
         self.delete_output_files()
         # advance baseline and reform Calculator objects to specified year

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -235,9 +235,9 @@ class TaxCalcIO():
         Delete all output files derived from self.output_filename.
         """
         extensions = [
-            '-params.bas',
-            '-params.ref',
-            '-tables.text',
+            '-params.baseline',
+            '-params.reform',
+            '.tables',
             '-atr.html',
             '-mtr.html',
             '-pch.html',
@@ -571,7 +571,7 @@ class TaxCalcIO():
         Write baseline and reform policy parameter values to separate files.
         """
         param_names = Policy.parameter_list()
-        fname = self.output_filename.replace('.xxx', '-params.bas')
+        fname = self.output_filename.replace('.xxx', '-params.baseline')
         with open(fname, 'w', encoding='utf-8') as pfile:
             for pname in param_names:
                 pval = self.calc_bas.policy_param(pname)
@@ -580,7 +580,7 @@ class TaxCalcIO():
             print(  # pragma: no cover
                 f'Write baseline policy parameter values to file {fname}'
             )
-        fname = self.output_filename.replace('.xxx', '-params.ref')
+        fname = self.output_filename.replace('.xxx', '-params.reform')
         with open(fname, 'w', encoding='utf-8') as pfile:
             for pname in param_names:
                 pval = self.calc_ref.policy_param(pname)
@@ -595,7 +595,7 @@ class TaxCalcIO():
         Write tables to text file.
         """
         # pylint: disable=too-many-locals
-        tab_fname = self.output_filename.replace('.xxx', '-tables.text')
+        tab_fname = self.output_filename.replace('.xxx', '.tables')
         # skip tables if there are not some positive weights
         if self.calc_bas.total_weight() <= 0.:
             with open(tab_fname, 'w', encoding='utf-8') as tfile:

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -522,7 +522,7 @@ def test_write_policy_param_files(reformfile1):
     assert not tcio.errmsg
     tcio.write_policy_params_files()
     outfilepath = tcio.output_filepath()
-    for ext in ['-params.bas', '-params.ref']:
+    for ext in ['-params.baseline', '-params.reform']:
         filepath = outfilepath.replace('.xxx', ext)
         if os.path.isfile(filepath):
             os.remove(filepath)

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -370,7 +370,7 @@ def test_ctor_init_with_cps_files():
     """
     # specify valid tax_year for cps.csv input data
     txyr = 2020
-    tcio = TaxCalcIO('cps.csv', txyr, None, None, None)
+    tcio = TaxCalcIO('cps.csv', txyr, None, None, None, runid=99)
     tcio.init('cps.csv', txyr, None, None, None,
               aging_input_data=True,
               exact_calculations=False)

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -370,16 +370,19 @@ def test_ctor_init_with_cps_files():
     """
     # specify valid tax_year for cps.csv input data
     txyr = 2020
-    tcio = TaxCalcIO('cps.csv', txyr, None, None, None, runid=99)
-    tcio.init('cps.csv', txyr, None, None, None,
-              aging_input_data=True,
-              exact_calculations=False)
-    assert not tcio.errmsg
-    assert tcio.tax_year() == txyr
-    # test advance_to_year method
-    tcio.silent = False
-    tcio.advance_to_year(txyr + 1, True)
-    assert tcio.tax_year() == txyr + 1
+    for rid in [0, 99]:
+        tcio = TaxCalcIO('cps.csv', txyr, None, None, None, runid=rid)
+        tcio.init(
+            'cps.csv', txyr, None, None, None,
+            aging_input_data=True,
+            exact_calculations=False,
+        )
+        assert not tcio.errmsg
+        assert tcio.tax_year() == txyr
+        # test advance_to_year method
+        tcio.silent = False
+        tcio.advance_to_year(txyr + 1, True)
+        assert tcio.tax_year() == txyr + 1
     # specify invalid tax_year for cps.csv input data
     txyr = 2013
     tcio = TaxCalcIO('cps.csv', txyr, None, None, None)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -931,8 +931,8 @@ def mtr_graph_data(vdf, year,
     ).values[:, 1]
     # construct DataFrame containing the two mtr?_series
     lines = pd.DataFrame()
-    lines['base'] = mtr1_series
-    lines['reform'] = mtr2_series
+    lines['base'] = np.round(mtr1_series, decimals=4)
+    lines['reform'] = np.round(mtr2_series, decimals=4)
     # construct dictionary containing merged data and auto-generated labels
     data = {}
     data['lines'] = lines
@@ -1065,8 +1065,8 @@ def atr_graph_data(vdf, year,
         where=avginc_series[included] != 0)
     # construct DataFrame containing the two atr?_series
     lines = pd.DataFrame()
-    lines['base'] = atr1_series
-    lines['reform'] = atr2_series
+    lines['base'] = np.round(atr1_series, decimals=4)
+    lines['reform'] = np.round(atr2_series, decimals=4)
     # include only percentiles with average income no less than min_avginc
     lines = lines[included]
     # construct dictionary containing plot lines and auto-generated labels
@@ -1237,7 +1237,7 @@ def pch_graph_data(vdf, year, pop_quantiles=False):
         where=avginc_series[included] != 0)
     # construct DataFrame containing the pch_series expressed as percent
     line = pd.DataFrame()
-    line['pch'] = pch_series * 100
+    line['pch'] = np.round(pch_series * 100, decimals=2)
     # include only percentiles with average income no less than min_avginc
     line = line[included]
     # construct dictionary containing plot line and auto-generated labels


### PR DESCRIPTION
This pull request streamlines `tc` output file extensions and adds the `--runid N` option that uses a simpler base output file name: `runN-YY`.   Using this new option produces output files with shorter names, but requires the `tc` user to keep track of which input data, baseline policy, and reform policy were used for the run.  Omitting the use of the new `--runid N` option will generate the legacy output file names.

