### PR TITLE
Add new OBBBA variables and associated parameters and tax logic

### DIFF
--- a/docs/guide/policy_params.md
+++ b/docs/guide/policy_params.md
@@ -2590,7 +2590,7 @@ _Valid Range:_ min = 0 and max = 9e+99
 _Out-of-Range Action:_ error
 
 
-### Regular: Non-AMT, Non-Pass-Through
+### Regular: Non-AMT
 
 ####  `II_rt1`
 _Description:_ The lowest tax rate, applied to the portion of taxable income below tax bracket 1.

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,4 @@ markers =
     reforms
     rtr
     stded
+    calc_and_used_vars

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with open("README.md", "r", encoding="utf-8") as f:
     longdesc = f.read()
 
-VERSION = "5.0.0"
+VERSION = "5.0.0a"
 
 config = {
     "description": "Tax-Calculator",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with open("README.md", "r", encoding="utf-8") as f:
     longdesc = f.read()
 
-VERSION = "5.0.0a"
+VERSION = "5.0.0b"
 
 config = {
     "description": "Tax-Calculator",

--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: taxcalc
-Version: 5.0.0
+Version: 5.0.0a0
 Summary: Tax-Calculator
 Home-page: https://github.com/PSLmodels/Tax-Calculator
 Download-URL: https://github.com/PSLmodels/Tax-Calculator

--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: taxcalc
-Version: 5.0.0a0
+Version: 5.0.0b0
 Summary: Tax-Calculator
 Home-page: https://github.com/PSLmodels/Tax-Calculator
 Download-URL: https://github.com/PSLmodels/Tax-Calculator

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -14,6 +14,6 @@ from taxcalc.taxcalcio import *
 from taxcalc.utils import *
 from taxcalc.cli import *
 
-__version__ = '5.0.0'
+__version__ = '5.0.0a'
 __min_python3_version__ = 10
 __max_python3_version__ = 12

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -14,6 +14,6 @@ from taxcalc.taxcalcio import *
 from taxcalc.utils import *
 from taxcalc.cli import *
 
-__version__ = '5.0.0a'
+__version__ = '5.0.0b'
 __min_python3_version__ = 10
 __max_python3_version__ = 12

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -14,9 +14,9 @@ import paramtools
 from taxcalc.calcfunctions import (TaxInc, SchXYZTax, GainsTax, AGIsurtax,
                                    NetInvIncTax, AMT, EI_PayrollTax, Adj,
                                    DependentCare, ALD_InvInc_ec_base, CapGains,
-                                   SSBenefits, UBI, AGI, ItemDed,
-                                   StdDed, AdditionalMedicareTax, F2441, EITC,
-                                   RefundablePayrollTaxCredit,
+                                   SSBenefits, UBI, AGI, AutoLoanInterestDed,
+                                   ItemDed, StdDed, AdditionalMedicareTax,
+                                   F2441, EITC, RefundablePayrollTaxCredit,
                                    ChildDepTaxCredit, AdditionalCTC, CTC_new,
                                    PersonalTaxCredit, SchR,
                                    AmOppCreditParts, EducationTaxCredit,
@@ -1391,6 +1391,7 @@ class Calculator():
         CapGains(self.__policy, self.__records)
         SSBenefits(self.__policy, self.__records)
         AGI(self.__policy, self.__records)
+        AutoLoanInterestDed(self.__policy, self.__records)
         ItemDed(self.__policy, self.__records)
         AdditionalMedicareTax(self.__policy, self.__records)
         StdDed(self.__policy, self.__records)

--- a/taxcalc/growdiff.json
+++ b/taxcalc/growdiff.json
@@ -282,7 +282,7 @@
     },
     "ATXPY": {
         "title": "ATXPY additive difference from default projection",
-        "description": "Default projection is in growfactors.csv file.  ATXPY extrapolates input variables: e00700, e00800, e01400, e01500, e01700, e03150, e03210, e03220, e03230, e03300, e03400, e03500, e07240, e07260, p08000, e09700, e09800, e09900, e11200, e18400, e18500, e19800, e20100, e20400, g20500, e07600, e32800, e58990, e62900, e87530, e87521 and cmbtp.",
+        "description": "Default projection is in growfactors.csv file.  ATXPY extrapolates input variables: e00700, e00800, e01400, e01500, e01700, e03150, e03210, e03220, e03230, e03300, e03400, e03500, e07240, e07260, p08000, e09700, e09800, e09900, e11200, e18400, e18500, e19800, e20100, e20400, g20500, e07600, e32800, e58990, e62900, e87530, e87521, cmbtp, and auto_loan_interest.",
         "type": "float",
         "value": [
             {
@@ -316,7 +316,7 @@
     },
     "AWAGE": {
         "title": "AWAGE additive difference from default projection",
-        "description": "Default projection is in growfactors.csv file.  AWAGE extrapolates input variables: e00200, e00200p and e00200s.  Also, AWAGE is the wage growth rate used to inflate the OASDI maximum taxable earnings policy parameter, _SS_Earnings_c.  Note that non-zero values of this parameter will not affect historically known values of _SS_Earnings_c.",
+        "description": "Default projection is in growfactors.csv file.  AWAGE extrapolates input variables: e00200, e00200p, e00200s, overtime_income, and tip_income.  Also, AWAGE is the wage growth rate used to inflate the OASDI maximum taxable earnings policy parameter, _SS_Earnings_c.  Note that non-zero values of this parameter will not affect historically known values of _SS_Earnings_c.",
         "type": "float",
         "value": [
             {

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -11597,11 +11597,11 @@
         }
     },
     "II_rt1": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 1",
+        "title": "Personal income (regular/non-AMT) tax rate 1",
         "description": "The lowest tax rate, applied to the portion of taxable income below tax bracket 1.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -11663,11 +11663,11 @@
         }
     },
     "II_brk1": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 1",
+        "title": "Personal income (regular/non-AMT) tax bracket (upper threshold) 1",
         "description": "Taxable income below this threshold is taxed at tax rate 1.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": true,
         "indexed": true,
         "type": "float",
@@ -12035,11 +12035,11 @@
         }
     },
     "II_rt2": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 2",
+        "title": "Personal income (regular/non-AMT) tax rate 2",
         "description": "The second lowest tax rate, applied to the portion of taxable income below tax bracket 2 and above tax bracket 1.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -12101,11 +12101,11 @@
         }
     },
     "II_brk2": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 2",
+        "title": "Personal income (regular/non-AMT) tax bracket (upper threshold) 2",
         "description": "Income below this threshold and above tax bracket 1 is taxed at tax rate 2.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": true,
         "indexed": true,
         "type": "float",
@@ -12473,11 +12473,11 @@
         }
     },
     "II_rt3": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 3",
+        "title": "Personal income (regular/non-AMT) tax rate 3",
         "description": "The third lowest tax rate, applied to the portion of taxable income below tax bracket 3 and above tax bracket 2.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -12539,11 +12539,11 @@
         }
     },
     "II_brk3": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 3",
+        "title": "Personal income (regular/non-AMT) tax bracket (upper threshold) 3",
         "description": "Income below this threshold and above tax bracket 2 is taxed at tax rate 3.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": true,
         "indexed": true,
         "type": "float",
@@ -12911,11 +12911,11 @@
         }
     },
     "II_rt4": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 4",
+        "title": "Personal income (regular/non-AMT) tax rate 4",
         "description": "The tax rate applied to the portion of taxable income below tax bracket 4 and above tax bracket 3.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -12977,11 +12977,11 @@
         }
     },
     "II_brk4": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 4",
+        "title": "Personal income (regular/non-AMT) tax bracket (upper threshold) 4",
         "description": "Income below this threshold and above tax bracket 3 is taxed at tax rate 4.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": true,
         "indexed": true,
         "type": "float",
@@ -13349,11 +13349,11 @@
         }
     },
     "II_rt5": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 5",
+        "title": "Personal income (regular/non-AMT) tax rate 5",
         "description": "The third highest tax rate, applied to the portion of taxable income below tax bracket 5 and above tax bracket 4.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -13415,11 +13415,11 @@
         }
     },
     "II_brk5": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 5",
+        "title": "Personal income (regular/non-AMT) tax bracket (upper threshold) 5",
         "description": "Income below this threshold and above tax bracket 4 is taxed at tax rate 5.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": true,
         "indexed": true,
         "type": "float",
@@ -13787,11 +13787,11 @@
         }
     },
     "II_rt6": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 6",
+        "title": "Personal income (regular/non-AMT) tax rate 6",
         "description": "The second higher tax rate, applied to the portion of taxable income below tax bracket 6 and above tax bracket 5.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -13853,11 +13853,11 @@
         }
     },
     "II_brk6": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket 6",
+        "title": "Personal income (regular/non-AMT) tax bracket 6",
         "description": "Income below this threshold and above tax bracket 5 is taxed at tax rate 6.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": true,
         "indexed": true,
         "type": "float",
@@ -14225,11 +14225,11 @@
         }
     },
     "II_rt7": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 7",
+        "title": "Personal income (regular/non-AMT) tax rate 7",
         "description": "The tax rate applied to the portion of taxable income below tax bracket 7 and above tax bracket 6.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -14291,11 +14291,11 @@
         }
     },
     "II_brk7": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket 7",
+        "title": "Personal income (regular/non-AMT) tax bracket 7",
         "description": "Income below this threshold and above tax bracket 6 is taxed at tax rate 7; income above this threshold is taxed at tax rate 8.  Default value is essentially infinity.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": true,
         "indexed": true,
         "type": "float",
@@ -14663,11 +14663,11 @@
         }
     },
     "II_rt8": {
-        "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 8",
+        "title": "Personal income (regular/non-AMT) tax rate 8",
         "description": "The tax rate applied to the portion of taxable income above tax bracket 7.",
         "notes": "",
         "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "section_2": "Regular: Non-AMT",
         "indexable": false,
         "indexed": false,
         "type": "float",
@@ -22186,6 +22186,147 @@
             {
                 "year": 2013,
                 "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "AutoLoanInterestDed_c": {
+        "title": "Maximum amount of auto loan interest that is deductible",
+        "description": "Auto loan interest in excess of this amount may not be deducted from AGI.",
+        "notes": "",
+        "section_1": "",
+        "section_2": "",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.0
+            },
+            {
+                "year": 2024,
+                "value": 0.0
+            },
+            {
+                "year": 2025,
+                "value": 10000.0
+            },
+            {
+                "year": 2028,
+                "value": 10000.0
+            },
+            {
+                "year": 2029,
+                "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "AutoLoanInterestDed_ps": {
+        "title": "Auto loan interest deduction phase-out start AGI",
+        "description": "Auto loan interest deduction is phased-out if AGI exceeds this amount.",
+        "notes": "",
+        "section_1": "",
+        "section_2": "",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 100000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 200000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 100000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 100000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 200000.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "AutoLoanInterestDed_po_step_size": {
+        "title": "Auto loan interest deduction phase-out AGI step size",
+        "description": "Auto loan interest deduction is phased-out in AGI steps of this size.",
+        "notes": "",
+        "section_1": "",
+        "section_2": "",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 1000.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "AutoLoanInterestDed_po_rate_per_step": {
+        "title": "Auto loan interest deduction phase-out rate per phase-out step",
+        "description": "Auto loan interest deduction is phased-out at this rate for each AGI step.",
+        "notes": "",
+        "section_1": "",
+        "section_2": "",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.20
             }
         ],
         "validators": {

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -22340,6 +22340,330 @@
             "cps": true
         }
     },
+    "ALD_OvertimeIncome_hc": {
+        "title": "Overtime income ALD haircut",
+        "description": "Overtime income ALD is subject to this haircut.",
+        "notes": "Final ALD amount is multiplied by (1-ALD_OvertimeIncome_hc).",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 1.0
+            },
+            {
+                "year": 2024,
+                "value": 1.0
+            },
+            {
+                "year": 2025,
+                "value": 0.0
+            },
+            {
+                "year": 2028,
+                "value": 0.0
+            },
+            {
+                "year": 2029,
+                "value": 1.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ALD_OvertimeIncome_c": {
+        "title": "Overtime ALD cap",
+        "description": "Overtime ALD is capped at this level.",
+        "notes": "",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 12500.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 25000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 12500.0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 12500.0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 12500.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ALD_OvertimeIncome_ps": {
+        "title": "Overtime ALD phase-out start earned income level",
+        "description": "Overtime ALD is phased-out if earned income exceeds this amount.",
+        "notes": "",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 150000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 300000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 150000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 150000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 150000.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ALD_OvertimeIncome_po_rate": {
+        "title": "Overtime ALD phase-out rate",
+        "description": "Overtime ALD is phased-out at this rate on earned income exceeding ALD_OvertimeIncome_ps.",
+        "notes": "",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.10
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ALD_TipIncome_hc": {
+        "title": "Tip income ALD haircut",
+        "description": "Tip income ALD is subject to this haircut.",
+        "notes": "Final ALD amount is multiplied by (1-ALD_TipIncome_hc).",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 1.0
+            },
+            {
+                "year": 2024,
+                "value": 1.0
+            },
+            {
+                "year": 2025,
+                "value": 0.0
+            },
+            {
+                "year": 2028,
+                "value": 0.0
+            },
+            {
+                "year": 2029,
+                "value": 1.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ALD_TipIncome_c": {
+        "title": "Tip ALD cap",
+        "description": "Tip ALD is capped at this level.",
+        "notes": "",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 25000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 25000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 25000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 25000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 25000.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ALD_TipIncome_ps": {
+        "title": "Tip ALD phase-out start earned income level",
+        "description": "Tip ALD is phased-out if earned income exceeds this amount.",
+        "notes": "",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": true,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 150000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 300000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 150000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 150000.0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 150000.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ALD_TipIncome_po_rate": {
+        "title": "Tip ALD phase-out rate",
+        "description": "Tip ALD is phased-out at this rate on earned income exceeding ALD_TipIncome_ps.",
+        "notes": "",
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.10
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
     "BEN_ssi_repeal": {
         "title": "SSI benefit repeal switch",
         "description": "SSI benefits can be repealed by switching this parameter to true.",

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -305,6 +305,8 @@ class Records(Data):
         self.e00200s *= gfv['AWAGE']
         self.pencon_p *= gfv['AWAGE']
         self.pencon_s *= gfv['AWAGE']
+        self.overtime_income *= gfv['AWAGE']
+        self.tip_income *= gfv['AWAGE']
         self.e00300 *= gfv['AINTS']
         self.e00400 *= gfv['AINTS']
         self.e00600 *= gfv['ADIVS']
@@ -377,6 +379,7 @@ class Records(Data):
         self.e87530 *= gfv['ATXPY']
         self.e87521 *= gfv['ATXPY']
         self.cmbtp *= gfv['ATXPY']
+        self.auto_loan_interest *= gfv['ATXPY']
         # BENEFITS
         self.other_ben *= gfv['ABENOTHER']
         self.mcare_ben *= gfv['ABENMCARE']

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -651,19 +651,19 @@
 
     "auto_loan_interest": {
       "type": "float",
-      "desc": "Filing unit's interest payments on qualified auto loans",
+      "desc": "Filing unit's interest payments on OBBBA-qualified auto loans",
       "form": {"2025-20??": "specified in custom data"},
       "availability": ""
     },
     "overtime_income": {
       "type": "float",
-      "desc": "Filing unit's qualified overtime income",
+      "desc": "Filing unit's OBBBA-qualified overtime income",
       "form": {"2025-20??": "specified in custom data"},
       "availability": ""
     },
     "tip_income": {
       "type": "float",
-      "desc": "Filing unit's qualified tip income",
+      "desc": "Filing unit's OBBBA-qualified tip income",
       "form": {"2025-20??": "specified in custom data"},
       "availability": ""
     }

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -1154,6 +1154,16 @@
       "desc": "Deduction for payment of qualified auto loan interest",
       "form": {"2025-20??": "calculated variable"}
     },
+    "ALD_OvertimeIncome": {
+      "type": "float",
+      "desc": "Above-the-line deduction for qualified overtime income",
+      "form": {"2025-20??": "calculated variable"}
+    },
+    "ALD_TipIncome": {
+      "type": "float",
+      "desc": "Above-the-line deduction for qualified tip income",
+      "form": {"2025-20??": "calculated variable"}
+    },
     "ubi": {
       "type": "float",
       "desc": "Universal Basic Income benefit for filing unit",

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -647,6 +647,25 @@
       "desc": "Filing unit's share of total business property owned by the pass-through business",
       "form": {"2018-20??": "specified in custom data"},
       "availability": ""
+    },
+
+    "auto_loan_interest": {
+      "type": "float",
+      "desc": "Filing unit's interest payments on qualified auto loans",
+      "form": {"2025-20??": "specified in custom data"},
+      "availability": ""
+    },
+    "overtime_income": {
+      "type": "float",
+      "desc": "Filing unit's qualified overtime income",
+      "form": {"2025-20??": "specified in custom data"},
+      "availability": ""
+    },
+    "tip_income": {
+      "type": "float",
+      "desc": "Filing unit's qualified tip income",
+      "form": {"2025-20??": "specified in custom data"},
+      "availability": ""
     }
   },
   "calc": {
@@ -1129,6 +1148,11 @@
       "type": "float",
       "desc": "search taxcalc/calcfunctions.py for how calculated and used",
       "form": {"2013-20??": "calculated variable"}
+    },
+    "auto_loan_interest_deduction": {
+      "type": "float",
+      "desc": "Deduction for payment of qualified auto loan interest",
+      "form": {"2025-20??": "calculated variable"}
     },
     "ubi": {
       "type": "float",

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -70,6 +70,7 @@ class GetFuncDefs(ast.NodeVisitor):
         self.generic_visit(node)
 
 
+@pytest.mark.calc_and_used_vars
 def test_calc_and_used_vars(tests_path):
     """
     Runs two kinds of tests on variables used in the calcfunctions.py file:
@@ -577,6 +578,7 @@ e02100 = [0.00, 0.00, 0.00, 0.00]
 e27200 = [0.00, 0.00, 0.00, 0.00]
 e00650 = [5000.00, 8000.00, 3000.00, 9000.00]
 c01000 = [7000.00, 4000.00, -3000.00, -3000.00]
+auto_loan_interest_deduction = [0.00, 0.00, 0.00, 1000.00]
 PT_SSTB_income = [0, 1, 1, 1]
 PT_binc_w2_wages = [0.00, 0.00, 0.00, 0.00]
 PT_ubia_property = [0.00, 0.00, 0.00, 0.00]
@@ -586,7 +588,8 @@ qbided = [0.0, 0.0, 0.0, 0.0]  # unimportant for function
 tuple0 = (
     c00100[0], standard[0], c04470[0], c04600[0], MARS[0], e00900[0],
     c03260[0], e26270[0],
-    e02100[0], e27200[0], e00650[0], c01000[0], PT_SSTB_income[0],
+    e02100[0], e27200[0], e00650[0], c01000[0],
+    auto_loan_interest_deduction[0], PT_SSTB_income[0],
     PT_binc_w2_wages[0], PT_ubia_property[0], PT_qbid_rt, PT_qbid_limited,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[0],
@@ -595,7 +598,8 @@ expected0 = (490860.66, 0)
 tuple1 = (
     c00100[1], standard[1], c04470[1], c04600[1], MARS[1], e00900[1],
     c03260[1], e26270[1],
-    e02100[1], e27200[1], e00650[1], c01000[1], PT_SSTB_income[1],
+    e02100[1], e27200[1], e00650[1], c01000[1],
+    auto_loan_interest_deduction[1], PT_SSTB_income[1],
     PT_binc_w2_wages[1], PT_ubia_property[1], PT_qbid_rt, PT_qbid_limited,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[1],
@@ -604,7 +608,8 @@ expected1 = (284400.08, 4275.02)
 tuple2 = (
     c00100[2], standard[2], c04470[2], c04600[2], MARS[2], e00900[2],
     c03260[2], e26270[2],
-    e02100[2], e27200[2], e00650[2], c01000[2], PT_SSTB_income[2],
+    e02100[2], e27200[2], e00650[2], c01000[2],
+    auto_loan_interest_deduction[2], PT_SSTB_income[2],
     PT_binc_w2_wages[2], PT_ubia_property[2], PT_qbid_rt, PT_qbid_limited,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[2],
@@ -613,12 +618,13 @@ expected2 = (579300.00, 0)
 tuple3 = (
     c00100[3], standard[3], c04470[3], c04600[3], MARS[3], e00900[3],
     c03260[3], e26270[3],
-    e02100[3], e27200[3], e00650[3], c01000[3], PT_SSTB_income[3],
+    e02100[3], e27200[3], e00650[3], c01000[3],
+    auto_loan_interest_deduction[3], PT_SSTB_income[3],
     PT_binc_w2_wages[3], PT_ubia_property[3], PT_qbid_rt, PT_qbid_limited,
     PT_qbid_taxinc_thd, PT_qbid_taxinc_gap, PT_qbid_w2_wages_rt,
     PT_qbid_alt_w2_wages_rt, PT_qbid_alt_property_rt, c04800[3],
     PT_qbid_ps, PT_qbid_prt, qbided[3])
-expected3 = (57500.00, 1200)
+expected3 = (56500.00, 1200)
 
 
 @pytest.mark.parametrize(

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -701,7 +701,7 @@ def test_section_titles(tests_path):
             cgqd_tax_same: 0
         },
         'Personal Income': {
-            'Regular: Non-AMT, Non-Pass-Through': 0,
+            'Regular: Non-AMT': 0,
             'Pass-Through': 0,
             'Alternative Minimum Tax': 0
         },


### PR DESCRIPTION
Add variables and parameters and tax-calculation logic for OBBBA auto loan interest deduction and for OBBBA above-the-line deductions for overtime income and tip income.   The CPS, PUF, and TMD input data sets do not (as yet) contain information on auto loan interest, overtime income, or tip income, but custom data can include these new variables.
