### PR TITLE
Add new SALT deduction cap phase-out parameters and associated logic

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -943,6 +943,7 @@ def ItemDed(e17500, e18400, e18500, e19200,
             ID_Medical_c, ID_StateLocalTax_c, ID_RealEstate_c,
             ID_InterestPaid_c, ID_Charity_c, ID_Casualty_c,
             ID_Miscellaneous_c, ID_AllTaxes_c, ID_AllTaxes_hc,
+            ID_AllTaxes_ps, ID_AllTaxes_po_rate, ID_AllTaxes_po_floor,
             ID_StateLocalTax_crt, ID_RealEstate_crt, ID_Charity_f,
             ID_reduction_salt_rate, ID_reduction_other_rate):
     """
@@ -1057,10 +1058,16 @@ def ItemDed(e17500, e18400, e18500, e19200,
         Ceiling on the amount of miscellaneous expense deduction
         allowed (dollars)
     ID_AllTaxes_c: list
-        Ceiling on the amount of state and local income, stales, and
+        Ceiling on the amount of state and local income, sales, and
         real estate deductions allowed (dollars)
     ID_AllTaxes_hc: float
         State and local income, sales, and real estate tax deduciton haircut
+    ID_AllTaxes_ps: float
+        AGI level above which ID_AllTaxes_c is reduced
+    ID_AllTaxes_po_rate: float
+        ID_AllTaxes_c reduction rate when AGI is above ID_AllTaxes_ps
+    ID_AllTaxes_po_floor: float
+        Floor below which ID_AllTaxes_c cannot be reduced
     ID_StateLocalTax_crt: float
         Ceiling (as decimal fraction of AGI) for the combination of all
         state and local income and sales tax deductions
@@ -1115,7 +1122,12 @@ def ItemDed(e17500, e18400, e18500, e19200,
     c18400 = min(c18400, ID_StateLocalTax_crt * max(c00100, 0.0001))
     c18500 = min(c18500, ID_RealEstate_crt * max(c00100, 0.0001))
     c18300 = (c18400 + c18500) * (1. - ID_AllTaxes_hc)
-    c18300 = min(c18300, ID_AllTaxes_c[MARS - 1])
+    cap = ID_AllTaxes_c[MARS - 1]
+    if posagi > ID_AllTaxes_ps[MARS - 1]:
+        excess_agi = posagi - ID_AllTaxes_ps[MARS - 1]
+        cap = max(0., cap - excess_agi * ID_AllTaxes_po_rate)
+        cap = max(cap, ID_AllTaxes_po_floor[MARS - 1])
+    c18300 = min(c18300, cap)
     # Interest paid
     c19200 = e19200 * (1. - ID_InterestPaid_hc)
     c19200 = min(c19200, ID_InterestPaid_c[MARS - 1])

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -943,7 +943,7 @@ def ItemDed(e17500, e18400, e18500, e19200,
             ID_Medical_c, ID_StateLocalTax_c, ID_RealEstate_c,
             ID_InterestPaid_c, ID_Charity_c, ID_Casualty_c,
             ID_Miscellaneous_c, ID_AllTaxes_c, ID_AllTaxes_hc,
-            ID_AllTaxes_ps, ID_AllTaxes_po_rate, ID_AllTaxes_po_floor,
+            ID_AllTaxes_c_ps, ID_AllTaxes_c_po_rate, ID_AllTaxes_c_po_floor,
             ID_StateLocalTax_crt, ID_RealEstate_crt, ID_Charity_f,
             ID_reduction_salt_rate, ID_reduction_other_rate):
     """
@@ -1058,15 +1058,15 @@ def ItemDed(e17500, e18400, e18500, e19200,
         Ceiling on the amount of miscellaneous expense deduction
         allowed (dollars)
     ID_AllTaxes_c: list
-        Ceiling on the amount of state and local income, sales, and
+        Cap on the amount of state and local income, sales, and
         real estate deductions allowed (dollars)
     ID_AllTaxes_hc: float
         State and local income, sales, and real estate tax deduciton haircut
-    ID_AllTaxes_ps: float
+    ID_AllTaxes_c_ps: float
         AGI level above which ID_AllTaxes_c is reduced
-    ID_AllTaxes_po_rate: float
-        ID_AllTaxes_c reduction rate when AGI is above ID_AllTaxes_ps
-    ID_AllTaxes_po_floor: float
+    ID_AllTaxes_c_po_rate: float
+        ID_AllTaxes_c reduction rate when AGI is above ID_AllTaxes_c_ps
+    ID_AllTaxes_c_po_floor: float
         Floor below which ID_AllTaxes_c cannot be reduced
     ID_StateLocalTax_crt: float
         Ceiling (as decimal fraction of AGI) for the combination of all
@@ -1123,10 +1123,10 @@ def ItemDed(e17500, e18400, e18500, e19200,
     c18500 = min(c18500, ID_RealEstate_crt * max(c00100, 0.0001))
     c18300 = (c18400 + c18500) * (1. - ID_AllTaxes_hc)
     cap = ID_AllTaxes_c[MARS - 1]
-    if posagi > ID_AllTaxes_ps[MARS - 1]:
-        excess_agi = posagi - ID_AllTaxes_ps[MARS - 1]
-        cap = max(0., cap - excess_agi * ID_AllTaxes_po_rate)
-        cap = max(cap, ID_AllTaxes_po_floor[MARS - 1])
+    if posagi > ID_AllTaxes_c_ps[MARS - 1]:
+        excess_agi = posagi - ID_AllTaxes_c_ps[MARS - 1]
+        cap = max(0., cap - excess_agi * ID_AllTaxes_c_po_rate)
+        cap = max(cap, ID_AllTaxes_c_po_floor[MARS - 1])
     c18300 = min(c18300, cap)
     # Interest paid
     c19200 = e19200 * (1. - ID_InterestPaid_hc)

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -6550,6 +6550,126 @@
             "cps": true
         }
     },
+    "ID_AllTaxes_ps": {
+        "title": "AGI level beyond which itemized AllTaxes deduction begins to be phased out",
+        "description": "The amount of state and local income, sales and real estate tax deductions is phased out when AGI exceeds this amount.",
+        "notes": "",
+        "section_1": "Itemized Deductions",
+        "section_2": "State And Local Taxes And Real Estate Taxes",
+        "indexable": true,
+        "indexed": true,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 9e+99
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 9e+99
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 9e+99
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 9e+99
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 9e+99
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ID_AllTaxes_po_rate": {
+        "title": "Rate at which itemized state and local income, sales and real estate tax deductions are phased-out above ID_AllTaxes_ps AGI",
+        "description": "The amount of state and local income, sales and real estate tax deductions is reduced at this rate when AGI exceeds ID_AllTaxes_ps.",
+        "notes": "",
+        "section_1": "Itemized Deductions",
+        "section_2": "State And Local Taxes And Real Estate Taxes",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "ID_AllTaxes_po_floor": {
+        "title": "Minimum cap on itemized state and local income, sales and real estate tax deductions that are phased-out above ID_AllTaxes_ps AGI",
+        "description": "The cap on state and local income, sales and real estate tax deductions cannot be reduced below this amount.",
+        "notes": "",
+        "section_1": "Itemized Deductions",
+        "section_2": "State And Local Taxes And Real Estate Taxes",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
+                "value": 0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
     "ID_InterestPaid_hc": {
         "title": "Interest paid deduction haircut",
         "description": "This decimal fraction can be applied to limit the amount of interest paid deduction allowed.",

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -6254,7 +6254,7 @@
         }
     },
     "ID_AllTaxes_c": {
-        "title": "Ceiling on the amount of state and local income, sales and real estate tax deductions allowed (dollars)",
+        "title": "Cap on the amount of state and local income, sales and real estate tax deductions allowed (dollars)",
         "description": "The amount of state and local income, sales and real estate tax deductions is limited to this dollar amount.",
         "notes": "",
         "section_1": "Itemized Deductions",
@@ -6550,9 +6550,9 @@
             "cps": true
         }
     },
-    "ID_AllTaxes_ps": {
-        "title": "AGI level beyond which itemized AllTaxes deduction begins to be phased out",
-        "description": "The amount of state and local income, sales and real estate tax deductions is phased out when AGI exceeds this amount.",
+    "ID_AllTaxes_c_ps": {
+        "title": "AGI level at which ID_AllTaxes_c cap starts to be phased out",
+        "description": "The cap on state and local income, sales and real estate tax deductions is phased out when AGI exceeds this amount.",
         "notes": "",
         "section_1": "Itemized Deductions",
         "section_2": "State And Local Taxes And Real Estate Taxes",
@@ -6597,9 +6597,9 @@
             "cps": true
         }
     },
-    "ID_AllTaxes_po_rate": {
-        "title": "Rate at which itemized state and local income, sales and real estate tax deductions are phased-out above ID_AllTaxes_ps AGI",
-        "description": "The amount of state and local income, sales and real estate tax deductions is reduced at this rate when AGI exceeds ID_AllTaxes_ps.",
+    "ID_AllTaxes_c_po_rate": {
+        "title": "Rate at which ID_AllTaxes_c cap is phased-out above ID_AllTaxes_c_ps AGI",
+        "description": "The cap on state and local income, sales and real estate tax deductions is reduced at this rate when AGI exceeds ID_AllTaxes_c_ps.",
         "notes": "",
         "section_1": "Itemized Deductions",
         "section_2": "State And Local Taxes And Real Estate Taxes",
@@ -6623,7 +6623,7 @@
             "cps": true
         }
     },
-    "ID_AllTaxes_po_floor": {
+    "ID_AllTaxes_c_po_floor": {
         "title": "Minimum cap on itemized state and local income, sales and real estate tax deductions that are phased-out above ID_AllTaxes_ps AGI",
         "description": "The cap on state and local income, sales and real estate tax deductions cannot be reduced below this amount.",
         "notes": "",


### PR DESCRIPTION
These changes should have been included in Tax-Calculator 5.1.0.

Three new parameters (and their associated logic) are added here, but at their pre-OBBBA values so that none of the test results change.   

The post-OBBBA values for the three new parameter will be added in PR #2937.