### PR TITLE
Fix OBBBA itemized deduction phase-out parameters and logic

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -945,7 +945,7 @@ def ItemDed(e17500, e18400, e18500, e19200,
             ID_Miscellaneous_c, ID_AllTaxes_c, ID_AllTaxes_hc,
             ID_AllTaxes_c_ps, ID_AllTaxes_c_po_rate, ID_AllTaxes_c_po_floor,
             ID_StateLocalTax_crt, ID_RealEstate_crt, ID_Charity_f,
-            ID_reduction_salt_rate, ID_reduction_other_rate):
+            ID_reduction_rate):
     """
     Calculates itemized deductions, Form 1040, Schedule A.
 
@@ -1076,10 +1076,8 @@ def ItemDed(e17500, e18400, e18500, e19200,
         state, local, and foreign real estate tax deductions
     ID_Charity_f: list
         Floor on the amount of charity expense deduction allowed (dollars)
-    ID_reduction_salt_rate: float
-        OBBBA reduction rate for SALT deductions
-    ID_reduction_other_rate: float
-        OBBBA reduction rate for other deductions
+    ID_reduction_rate: float
+        OBBBA reduction rate for all itemized deductions
 
     Returns
     -------
@@ -1166,16 +1164,11 @@ def ItemDed(e17500, e18400, e18500, e19200,
     # OBBBA limitation on total itemized deductions
     # (no attempt to adjust c04470 components for limitation)
     reduction = 0.
-    if ID_reduction_salt_rate > 0. or ID_reduction_other_rate > 0.:
+    if ID_reduction_rate > 0.:
         assert c21040 <= 0.0, "Pease and OBBBA cannot both be in effect"
         tincome = max(0., c00100 - c04600)
         texcess = max(0., tincome - II_brk6[MARS - 1])
-        smaller_salt = min(c18300, texcess)
-        salt_reduction = ID_reduction_salt_rate * smaller_salt
-        other_deds = max(0, c04470 - c18300)
-        smaller_other = min(other_deds, texcess)
-        other_reduction = ID_reduction_other_rate * smaller_other
-        reduction = salt_reduction + other_reduction
+        reduction = ID_reduction_rate * texcess
     c04470 = max(0., c04470 - reduction)
     # Cap total itemized deductions
     # (no attempt to adjust c04470 components for limitation)

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -8906,40 +8906,10 @@
             "cps": true
         }
     },
-    "ID_reduction_salt_rate": {
-        "title": "Itemized deduction reduction rate for SALT deductions under OBBBA",
+    "ID_reduction_rate": {
+        "title": "Itemized deduction reduction rate under OBBBA",
         "description": "Itemized deductions are reduced if pre-deduction taxable income exceeds top tax bracket.",
-        "notes": "The 2026 value of 0.13513514 is about equal to 5/37.",
-        "section_1": "Itemized Deductions",
-        "section_2": "Itemized Deduction Limitation",
-        "indexable": false,
-        "indexed": false,
-        "type": "float",
-        "value": [
-            {
-                "year": 2013,
-                "value": 0.0
-            },
-            {
-                "year": 2026,
-                "value": 0.0
-            }
-        ],
-        "validators": {
-            "range": {
-                "min": 0,
-                "max": 1
-            }
-        },
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        }
-    },
-    "ID_reduction_other_rate": {
-        "title": "Itemized deduction reduction rate for non-SALT deductions under OBBBA",
-        "description": "Itemized deductions are reduced if pre-deduction taxable income exceeds top tax bracket.",
-        "notes": "The 2026 value of 0.05405405 is about equal to 2/37.",
+        "notes": "The 2026+ value of 0.05405405 is about equal to 2/37.",
         "section_1": "Itemized Deductions",
         "section_2": "Itemized Deduction Limitation",
         "indexable": false,


### PR DESCRIPTION
This PR fixes the recent changes made in pull request #2933.   PR #2933 implemented the itemized deduction reduction logic in the House-passed version of OBBBA, not the Senate-passed and final version of OBBBA.   The need to fix the changes in PR #2933 was identified by @maxkossek in his review of pull request #2937.