### PR TITLE
Allow CLI --dumpvars DUMPVARS to be the ALL string

### DIFF
--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -129,7 +129,9 @@ def cli_tc_main():
                               'a minimal set of variables.  Valid variable '
                               'names include all variables in the '
                               'records_variables.json file plus mtr_itax and '
-                              'mtr_ptax (MTRs wrt taxpayer earnings).'),
+                              'mtr_ptax (MTRs wrt taxpayer earnings).  If '
+                              'DUMPVARS is ALL, then all valid variable names '
+                              'are included in the dump database.'),
                         default=None)
     parser.add_argument('--runid', metavar='N',
                         help=('N is a positive integer run id that is used '
@@ -246,7 +248,9 @@ def cli_tc_main():
     # specify dumpvars_str from args.dumpvars file
     dumpvars_str = ''
     if args.dumpvars:
-        if os.path.exists(args.dumpvars):
+        if args.dumpvars == 'ALL':
+            dumpvars_str = 'ALL'
+        elif os.path.exists(args.dumpvars):
             with open(args.dumpvars, 'r', encoding='utf-8') as dfile:
                 dumpvars_str = dfile.read()
         else:

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -134,21 +134,25 @@ def test_read_data(csv):
 def test_for_duplicate_names():
     """Test docstring"""
     records_varinfo = Records(data=None)
+    num_vars = 0
     varnames = set()
     for varname in records_varinfo.USABLE_READ_VARS:
         assert varname not in varnames
         varnames.add(varname)
         assert varname not in records_varinfo.CALCULATED_VARS
+    num_vars += len(varnames)
     varnames = set()
     for varname in records_varinfo.CALCULATED_VARS:
         assert varname not in varnames
         varnames.add(varname)
         assert varname not in records_varinfo.USABLE_READ_VARS
+    num_vars += len(varnames)
     varnames = set()
     for varname in records_varinfo.INTEGER_READ_VARS:
         assert varname not in varnames
         varnames.add(varname)
         assert varname in records_varinfo.USABLE_READ_VARS
+    assert num_vars == 212  # number of vars in records_variables.json
 
 
 def test_records_variables_content(tests_path):

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -397,7 +397,13 @@ def test_ctor_init_with_cps_files():
     MARS;iitax	payrolltax|combined,
     c00100
     surtax
-    """, True, 6),  # these 6 parameters minus MARS plus RECID
+    """, True, 6),  # these 6 variables minus MARS plus RECID
+
+    ('ALL', True, 209),
+    # 209 =
+    # all 212 vars in records_variables.json
+    # minus 5 TaxCalcIO.BASE_DUMPVARS (omitting RECID)
+    # plus 2 TaxCalcIO.MTR_DUMPVAR
 
     ("""
     MARS;iitax	payrolltax|kombined,c00100

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -401,9 +401,9 @@ def test_ctor_init_with_cps_files():
 
     ('ALL', True, 209),
     # 209 =
-    # all 212 vars in records_variables.json
-    # minus 5 TaxCalcIO.BASE_DUMPVARS (omitting RECID)
-    # plus 2 TaxCalcIO.MTR_DUMPVAR
+    # all 212 vars in records_variables.json (see test_records.py)
+    # minus 5 TaxCalcIO.BASE_DUMPVARS omitting RECID (see taxcalcio.py)
+    # plus 2 TaxCalcIO.MTR_DUMPVARS (see taxcalcio.py)
 
     ("""
     MARS;iitax	payrolltax|kombined,c00100


### PR DESCRIPTION
Using ALL for DUMPVARS causes all input and calculated variables (including the two MTR variables) to be included in the `.dumpdb` output file.
