### PR TITLE
Require behavioral responses with install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ config = {
         "bokeh>=2.4",
         "numba",
         "paramtools>=0.20.0",
+        "behresp"
     ],
     "classifiers": [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
With other packages that depend on `taxcalc`, I get the following error unless I manually install the Behavioral-Responses package:
```
packages/taxcalc/taxcalcio.py", line 16, in <module>
    import behresp
ModuleNotFoundError: No module named 'behresp'
```

I believe adding `behresp` to the list of packages in `install_requires` of `setup.py` will ensure that this critical dependency is installed with `taxcalc`.