### PR TITLE
Prepare release 6.5.3

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -5,6 +5,23 @@ Go
 for a complete commit history.
 
 
+2026-04-27 Release 6.5.3
+------------------------
+(last merged pull request is
+[#3014](https://github.com/PSLmodels/Tax-Calculator/pull/3014))
+
+**This is a bug-fix release.**
+
+**API Changes**
+
+**New Features**
+
+**Bug Fixes**
+- Make phase-out of OBBBA senior deduction be per person (not per tax unit).
+  [[#3014](https://github.com/PSLmodels/Tax-Calculator/pull/3014)
+  by Martin Holmer]
+
+
 2026-04-13 Release 6.5.2
 ------------------------
 (last merged pull request is

--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -8,7 +8,7 @@ for a complete commit history.
 2026-04-27 Release 6.5.3
 ------------------------
 (last merged pull request is
-[#3014](https://github.com/PSLmodels/Tax-Calculator/pull/3014))
+[#3016](https://github.com/PSLmodels/Tax-Calculator/pull/3016))
 
 **This is a bug-fix release.**
 
@@ -19,6 +19,9 @@ for a complete commit history.
 **Bug Fixes**
 - Make phase-out of OBBBA senior deduction be per person (not per tax unit).
   [[#3014](https://github.com/PSLmodels/Tax-Calculator/pull/3014)
+  by Martin Holmer]
+- Correct exact (stair-step) phase-out of OBBBA overtime and tip deductions.
+  [[#3016](https://github.com/PSLmodels/Tax-Calculator/pull/3016)
   by Martin Holmer]
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ cross-model validation work with NBER's TAXSIM-35 model is described
 
 ## Latest release
 
-{doc}`6.5.2 (2026-04-13) <about/releases>`
+{doc}`6.5.3 (2026-04-27) <about/releases>`
 
 If you are already using Tax-Calculator, upgrade using the following command:
 ```

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with open("README.md", "r", encoding="utf-8") as f:
     longdesc = f.read()
 
-VERSION = "6.5.2"
+VERSION = "6.5.3"
 
 config = {
     "description": "Tax-Calculator",

--- a/taxcalc.egg-info/PKG-INFO
+++ b/taxcalc.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: taxcalc
-Version: 6.5.2
+Version: 6.5.3
 Summary: Tax-Calculator
 Home-page: https://github.com/PSLmodels/Tax-Calculator
 Download-URL: https://github.com/PSLmodels/Tax-Calculator

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -14,6 +14,6 @@ from taxcalc.taxcalcio import *
 from taxcalc.utils import *
 from taxcalc.cli import *
 
-__version__ = '6.5.2'
+__version__ = '6.5.3'
 __min_python3_version__ = 11
 __max_python3_version__ = 13


### PR DESCRIPTION
This PR prepares Tax-Calculator release 6.5.3, which is dated 2026-04-27.
