### PR TITLE
Fix 2018-2020 values of `ALD_Tuition_hc` policy parameter

### DIFF
--- a/docs/guide/policy_params.md
+++ b/docs/guide/policy_params.md
@@ -554,7 +554,7 @@ _Out-of-Range Action:_ error
 
 ####  `ALD_Tuition_hc`
 _Description:_ If greater than zero, this decimal fraction reduces the portion of tuition and fees that can be deducted from AGI.
-_Notes:_ The final adjustment amount would be (1-Haircut)*TuitionFees.
+_Notes:_ The final adjustment amount would be (1-Haircut)*TuitionFees.  Set to 1.0 starting 2021: IRC §222 was permanently repealed for tax years beginning after 2020-12-31 by §104 of the Taxpayer Certainty and Disaster Tax Relief Act of 2020.
 _Has An Effect When Using:_ _PUF data:_ True _CPS data:_ False
 _Can Be Inflation Indexed:_ False _Is Inflation Indexed:_ False
 _Value Type:_ float
@@ -564,8 +564,10 @@ _Known Values:_
 2015: 0.0
 2016: 0.0
 2017: 0.0
-2018: 1.0
-2019: 1.0
+2018: 0.0
+2019: 0.0
+2020: 0.0
+2021: 1.0
 _Valid Range:_ min = 0 and max = 1
 _Out-of-Range Action:_ error
 

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -377,7 +377,7 @@ def Adj(e03220, e03290, c03260, e03300, e03270,
         Student loan interest paid (Sch 1 line 21)
     e03230: float
         Tuition and fees, Form 8917
-        (legacy; expired after 2017)
+        (legacy; permanently repealed for tax years after 2020)
     e03240: float
         Domestic production activity deduction, Form 8903
         (legacy; expired after 2017)
@@ -422,7 +422,7 @@ def Adj(e03220, e03290, c03260, e03300, e03270,
         (1. - ALD_AlimonyPaid_hc) * e03500 +         # Sch 1 line 19a
         (1. - ALD_IRAContributions_hc) * e03150 +    # Sch 1 line 20
         (1. - ALD_StudentLoan_hc) * e03210 +         # Sch 1 line 21
-        (1. - ALD_Tuition_hc) * e03230 +             # ALD expired post-2017
+        (1. - ALD_Tuition_hc) * e03230 +             # ALD repealed post-2020
         (1. - ALD_DomesticProduction_hc) * e03240 +  # ALD expired post-2017
         care_deduction                               # ALD reform construct
     )

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -996,7 +996,7 @@
     },
     "ALD_Tuition_hc": {
         "title": "Deduction for tuition and fees haircut",
-        "description": "If greater than zero, this decimal fraction reduces the portion of tuition and fees that can be deducted from AGI.  The final adjustment amount would be (1-Haircut)*TuitionFees.",
+        "description": "If greater than zero, this decimal fraction reduces the portion of tuition and fees that can be deducted from AGI.  The final adjustment amount would be (1-Haircut)*TuitionFees.  Set to 1.0 starting 2021: IRC §222 was permanently repealed for tax years beginning after 2020-12-31 by §104 of the Taxpayer Certainty and Disaster Tax Relief Act of 2020.",
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
         "indexable": false,
@@ -1024,7 +1024,7 @@
                 "value": 0.0
             },
             {
-                "year": 2018,
+                "year": 2021,
                 "value": 1.0
             }
         ],


### PR DESCRIPTION
Code change (taxcalc/policy_current_law.json): `ALD_Tuition_hc` schedule shifted from 
{2018: 1.0} to {2021: 1.0}. 

Years 2018-2020 now correctly carry forward 0.0 from 2017, matching the actual repeal date (IRC §222 was repealed by §104 of the Taxpayer Certainty and Disaster Tax Relief Act of 2020 for tax years after 2020-12-31, not after 2017).

**BACKGROUND**

What federal law actually did: §222 was repeatedly extended past 2017. The relevant statute is §104 of the Taxpayer Certainty and Disaster Tax Relief Act of 2020 (Division EE of the Consolidated Appropriations Act, 2021), which permanently repealed §222 for tax years beginning after December 31, 2020, paired with an expansion of the Lifetime Learning Credit phase-out as the replacement. The IRS published Form 8917 for tax years 2018, 2019, and 2020; taxpayers actually claimed the deduction in those years.

So the haircut step from 0.0 to 1.0 should occur in 2021, not 2018.

