### PR TITLE
Fix `AmOppCreditParts` function nonrefundable haircut formula

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -3624,8 +3624,10 @@ def AmOppCreditParts(exact, e87521, num, c00100, CR_AmOppRefundable_hc,
         # ---- Total AOTC after phaseout (line 7) ----
         line7 = line6_x1000 * e87521 / 1000.
         # ---- Refundable (line 8) / nonrefundable (Part II line 9) split ----
-        c10960 = 0.4 * line7 * (1. - CR_AmOppRefundable_hc)
-        c87668 = line7 - c10960 * (1. - CR_AmOppNonRefundable_hc)
+        ref_portion = 0.4 * line7             # Form 8863 line 8 base
+        nonref_portion = line7 - ref_portion  # Part II line 9 base = 0.6*line7
+        c10960 = ref_portion * (1. - CR_AmOppRefundable_hc)
+        c87668 = nonref_portion * (1. - CR_AmOppNonRefundable_hc)
     else:
         c10960 = 0.
         c87668 = 0.


### PR DESCRIPTION
The CR_AmOppNonRefundable_hc parameter description states
"Credit claimed will be
 (1-Haircut)*NonRefundablePortionOfAmericanOpportunityCredit",
but the prior formula:
```
      c87668 = line7 - c10960 * (1. - CR_AmOppNonRefundable_hc)
```
mis-applied the haircut: it subtracted the haircut-already-applied
refundable amount c10960 (not the on-form 0.4*line7 base) from line 7,
so the two haircuts interacted instead of acting independently on
their respective on-form portions.

Replace with the symmetric, form-faithful pair:
```
      ref_portion = 0.4 * line7              # Form 8863 line 8 base
      nonref_portion = line7 - ref_portion   # Part II line 9 = 0.6*line7
      c10960 = ref_portion * (1. - CR_AmOppRefundable_hc)
      c87668 = nonref_portion * (1. - CR_AmOppNonRefundable_hc)
```

Current-law behavior is unchanged because both haircuts default to 0.0
for all years 2013+, leaving c10960 = 0.4*line7 and c87668 = 0.6*line7
either way. The fix matters only for reforms that set
CR_AmOppNonRefundable_hc != 0.
