### PR TITLE
SSBenefits docstring: document MFS-lived-with-spouse modeling gap

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -693,8 +693,17 @@ def SSBenefits(MARS, ymod, e02400, SS_all_in_agi, SS_thd1, SS_thd2,
                                                                 thd2 - thd1),
                                                      p2 * e02400)
     where ymod is the worksheet line 7 amount built in AGIIncome.
-    Note: MARS=3 thresholds correspond to "MFS lived apart all year";
-    Tax-Calculator does not model the MFS-lived-together case (base = 0).
+
+    MARS=3 (MFS) sub-case modeling gap: worksheet line 8 gives a base
+    of $0 for MFS filers who "lived with [their] spouse at any time
+    during the year" (instructions further direct such filers to skip
+    lines 8-15 and enter 0.85 * line 1 directly on line 16, i.e. 85%
+    of OASDI is taxable). `SS_thd1[2]`/`SS_thd2[2]` ($25,000/$34,000)
+    encode only the "MFS lived apart all year" case. Tax-Calculator
+    records do not carry a lived-apart-all-year flag (same data-gap
+    pattern as Schedule R row 26 in CODE_REVIEW_2025.md), so the code
+    unconditionally treats every MARS=3 filer as lived-apart and
+    under-taxes MFS-lived-with-spouse filers. Not fixable code-side.
 
     The reform flag SS_all_in_agi (default False under current law)
     overrides the worksheet and includes 100% of OASDI in AGI.


### PR DESCRIPTION
Pub. 915 SS Benefits Worksheet line 8 directs MFS filers who lived
with their spouse at any time in the year to use a $0 base (and skip
lines 8-15, so 85% of OASDI is taxable on line 16). SS_thd1[2] and
SS_thd2[2] encode only the lived-apart-all-year case. Tax-Calculator
records do not carry a lived-apart-all-year flag, so the function
unconditionally treats every MARS=3 filer as lived-apart and
under-taxes MFS-lived-with-spouse filers. Same data-gap pattern as the
Schedule R MFS limitation; not fixable code-side.

Docstring-only change; no tax-logic change.
