### PR TITLE
Fix typos in `docs/about/releases.md` documentation

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -47,11 +47,11 @@ for a complete commit history.
 - Fix QBID bugs in `TaxIncome` function.  Effect:
     tmd-26.tables: 2644.3 → 2645.3 (+0.04 percent relative change).
   [[#3042](https://github.com/PSLmodels/Tax-Calculator/pull/3042)
-   by Martin Holmer with the assistant of Claude Code]
+   by Martin Holmer with the assistance of Claude Code]
 - Fix `AMT` function bugs.  Effect:
    tmd-26.tables: 2645.3 → 2644.0 (-0.05 percent relative change).
   [[#3049](https://github.com/PSLmodels/Tax-Calculator/pull/3049)
-   by Martin Holmer with the assistant of Claude Code]
+   by Martin Holmer with the assistance of Claude Code]
 
 
 2026-04-27 Release 6.5.3

--- a/docs/contributing/RELEASING.md
+++ b/docs/contributing/RELEASING.md
@@ -15,8 +15,8 @@ In the top-level Tax-Calculator directory, do the following:
 --> run `python update_pcl.py`  [to update policy_current_law.json]
 --> run `make cstest`  [to confirm project coding style is being followed]
 --> run `make pytest-all`  [to confirm all pytest test are passing]
---> run `make idtest`  [to check CLI results for CPS, PUF, TMD input data]
 --> run `make brtest`  [to check CLI results for behavioral responses]
+--> run `make idtest`  [to check CLI results for CPS and TMD input data]
 --> run `make tctest-jit`  [to ensure JIT decorators are not hiding bugs]
 --> commit X-Y-Z branch and push to origin
 --> open new GitHub pull request using your X-Y-Z branch


### PR DESCRIPTION
Fixes two spelling errors.