### PR TITLE
Prepare release 6.6.1

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -5,7 +5,7 @@ Go
 for a complete commit history.
 
 
-2026-05-xx Release 6.6.1
+2026-05-27 Release 6.6.1
 ------------------------
 (last merged pull request is
 [#3072](https://github.com/PSLmodels/Tax-Calculator/pull/3072))

--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -5,6 +5,27 @@ Go
 for a complete commit history.
 
 
+2026-05-xx Release 6.6.1
+------------------------
+(last merged pull request is
+[#3072](https://github.com/PSLmodels/Tax-Calculator/pull/3072))
+
+**This is a bug-fix release.**
+
+**API Changes**
+
+**New Features**
+
+**Bug Fixes**
+
+- Fixes issue #3071 by adding a new parameter called `soi_iitax` that
+  controls the categorization of the self-employment tax (`setax`) and
+  the additional Medicare tax (`ptax_amc`) as being part of the income
+  tax or as being part of the payroll tax.
+  [[#3072](https://github.com/PSLmodels/Tax-Calculator/pull/3072)
+  by Martin Holmer]
+
+
 2026-05-18 Release 6.6.0
 ------------------------
 (last merged pull request is

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ cross-model validation work with NBER's TAXSIM-35 model is described
 
 ## Latest release
 
-{doc}`6.6.1 (2026-05-xx) <about/releases>`
+{doc}`6.6.1 (2026-05-27) <about/releases>`
 
 If you are already using Tax-Calculator, upgrade using the following command:
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ cross-model validation work with NBER's TAXSIM-35 model is described
 
 ## Latest release
 
-{doc}`6.6.0 (2026-05-18) <about/releases>`
+{doc}`6.6.1 (2026-05-xx) <about/releases>`
 
 If you are already using Tax-Calculator, upgrade using the following command:
 ```


### PR DESCRIPTION
The release date in the `docs/about/releases.md` file and the `docs/index.md` file is set to 2026-05-27.
Revise the date in those two files if packages cannot be made available on May 27th.