### PR TITLE
Add logic for refundable credit claiming behavior

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -3209,21 +3209,22 @@ def EITC(eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
             c59660 = max(0., c59660 - red)
 
     # ---------------- (E) Credit claiming logic ----------
-    # Notice that `eitc_claim_prob_scale` and `eitc_claim_thd` can be used
-    # together to specify non-linear claiming probability schedules.
-    #
-    # Not on the form: credit claiming logic that uses claiming probability
-    # (default eitc_claim_prob_scale=9e99 implies always claim credit amount)
-    if max_amount > 0.:
+    if c59660 > 0.:
+        #
+        # Notice that `eitc_claim_prob_scale` and `eitc_claim_thd` can be used
+        # together to specify non-linear claiming probability schedules.
+        #
+        # Not on the form: credit claiming logic that uses claiming probability
+        # (default eitc_claim_prob_scale=9e99 implies always claim credit)
         prob = eitc_claim_prob_scale * c59660 / max_amount
         if credit_claim_urn >= prob:
             c59660 = 0.
-    #
-    # Not on the form: filers with credit amount less than eitc_claim_thd
-    # are assumed not to claim
-    # (default eitc_claim_thd=0 implies always claim credit amount)
-    if c59660 < eitc_claim_thd:
-        c59660 = 0.
+        #
+        # Not on the form: filers with credit amount less than eitc_claim_thd
+        # are assumed not to claim
+        # (default eitc_claim_thd=0 implies always claim credit)
+        if c59660 < eitc_claim_thd:
+            c59660 = 0.
 
     return c59660
 
@@ -4258,8 +4259,8 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
 
 
 @iterate_jit(nopython=True)
-def AdditionalCTC(actc_claim_thd, codtc_limited,
-                  ACTC_c, n24, earned, ACTC_Income_thd,
+def AdditionalCTC(actc_claim_thd, actc_claim_prob_scale, credit_claim_urn,
+                  codtc_limited, ACTC_c, n24, earned, ACTC_Income_thd,
                   ACTC_rt, nu06, ACTC_rt_bonus_under6family, ACTC_ChildNum,
                   CTC_is_refundable, CTC_include17, CTC_c,
                   age_head, age_spouse, MARS, nu18,
@@ -4272,7 +4273,12 @@ def AdditionalCTC(actc_claim_thd, codtc_limited,
     Parameters
     ----------
     actc_claim_thd: float
-        ACTC amount below which ACTC is unclaimed
+        Model-specific behavioral parameter: ACTC amount below which
+        the credit is assumed unclaimed (no form analogue)
+    actc_claim_prob_scale: float
+        See logic and comments at bottom of function (no form analogue)
+    credit_claim_urn: float
+        See logic and comments at bottom of function (no form analogue)
     codtc_limited: float
         Sch 8812 line 16a: Part I tentative credit minus the nonrefundable
         portion absorbed (line 12 minus line 14); set in ChildDepTaxCredit
@@ -4313,6 +4319,7 @@ def AdditionalCTC(actc_claim_thd, codtc_limited,
     c11070: float
         Child tax credit (refunded) from Form 8812
     """
+    # pylint: disable=too-many-branches
     # Sch 8812 line 16a: leftover Part I tentative credit
     line16a = codtc_limited
     # Sch 8812 line 16b: max refundable amount = ACTC_c per qualifying child
@@ -4366,8 +4373,23 @@ def AdditionalCTC(actc_claim_thd, codtc_limited,
                 c11070 = min(line17, line27)
 
     # approximate ACTC claiming behavior
-    if c11070 < actc_claim_thd:
-        c11070 = 0.
+    if c11070 > 0.:
+        #
+        # Notice that `actc_claim_prob_scale` and `actc_claim_thd` can be used
+        # together to specify non-linear claiming probability schedules.
+        #
+        # Not on the form: credit claiming logic that uses claiming probability
+        # (default actc_claim_prob_scale=9e99 implies always claim credit)
+        max_amount = ACTC_c * childnum
+        prob = actc_claim_prob_scale * c11070 / max_amount
+        if credit_claim_urn >= prob:
+            c11070 = 0.
+        #
+        # Not on the form: filers with credit amount less than actc_claim_thd
+        # are assumed not to claim
+        # (default actc_claim_thd=0 implies always claim credit)
+        if c11070 < actc_claim_thd:
+            c11070 = 0.
 
     return c11070
 

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -3005,7 +3005,8 @@ def EITCamount(basic_frac, phasein_rate, earnings, max_amount,
 
 
 @iterate_jit(nopython=True)
-def EITC(eitc_claim_thd, MARS, DSI, c00100, e00300, e00400, e00600, c01000,
+def EITC(eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
+         MARS, DSI, c00100, e00300, e00400, e00600, c01000,
          e02000, e26270, age_head, age_spouse, earned, earned_p, earned_s, EIC,
          EITC_ps, EITC_MinEligAge, EITC_MaxEligAge, EITC_ps_addon_MarriedJ,
          EITC_rt, EITC_c, EITC_prt, EITC_basic_frac,
@@ -3049,9 +3050,8 @@ def EITC(eitc_claim_thd, MARS, DSI, c00100, e00300, e00400, e00600, c01000,
           `EITC_InvestIncome_c` ($11,950 for 2025) is modeled as a
           smooth phaseout at `EITC_excess_InvestIncome_rt` (default
           9e+99 → behaviorally identical to the cliff).
-      (E) Model-specific claiming approximation: filers with expected
-          credit below `eitc_claim_thd` (default 0) are assumed not to
-          claim.  No form analogue.
+      (E) Model-specific claiming approximation: see details below.
+          No form analogue.
 
     Downstream: `c59660` is the records-bound EITC amount consumed by
     `IITAX` (Form 1040 line 27a, refundable credit) and reported in
@@ -3062,6 +3062,10 @@ def EITC(eitc_claim_thd, MARS, DSI, c00100, e00300, e00400, e00600, c01000,
     eitc_claim_thd: float
         Model-specific behavioral parameter: EITC amount below which
         the credit is assumed unclaimed (no form analogue)
+    eitc_claim_prob_scale: float
+        See Section E logic and comments (no form analogue)
+    credit_claim_urn: float
+        See Section E logic and comments (no form analogue)
     MARS: int
         Filing (marital) status (1=single, 2=joint, 3=separate,
                                  4=household-head, 5=widow(er))
@@ -3204,9 +3208,17 @@ def EITC(eitc_claim_thd, MARS, DSI, c00100, e00300, e00400, e00600, c01000,
             red = EITC_excess_InvestIncome_rt * (invinc - EITC_InvestIncome_c)
             c59660 = max(0., c59660 - red)
 
-    # ---------------- (E) Behavioral claiming approximation ----------
-    # Not on the form: filers with expected credit < eitc_claim_thd
-    # are assumed not to claim (default 0 = no suppression).
+    # ---------------- (E) Credit claiming logic ----------
+    # Not on the form: credit claiming logic that uses claiming probability
+    # (default 9e99 implies always claim credit amount)
+    assert credit_claim_urn > 0.
+    assert credit_claim_urn < 1.
+    if max_amount > 0.:
+        prob = eitc_claim_prob_scale * c59660 / max_amount
+        if credit_claim_urn >= prob:
+            c59660 = 0.
+    # Not on the form: filers with credit amount less than eitc_claim_thd
+    # are assumed not to claim (default 0 implies always claim credit amount)
     if c59660 < eitc_claim_thd:
         c59660 = 0.
 

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -4380,7 +4380,7 @@ def AdditionalCTC(actc_claim_thd, actc_claim_prob_scale, credit_claim_urn,
         #
         # Not on the form: credit claiming logic that uses claiming probability
         # (default actc_claim_prob_scale=9e99 implies always claim credit)
-        max_amount = ACTC_c * childnum
+        max_amount = line17
         prob = actc_claim_prob_scale * c11070 / max_amount
         if credit_claim_urn >= prob:
             c11070 = 0.

--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -3209,16 +3209,19 @@ def EITC(eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
             c59660 = max(0., c59660 - red)
 
     # ---------------- (E) Credit claiming logic ----------
+    # Notice that `eitc_claim_prob_scale` and `eitc_claim_thd` can be used
+    # together to specify non-linear claiming probability schedules.
+    #
     # Not on the form: credit claiming logic that uses claiming probability
-    # (default 9e99 implies always claim credit amount)
-    assert credit_claim_urn > 0.
-    assert credit_claim_urn < 1.
+    # (default eitc_claim_prob_scale=9e99 implies always claim credit amount)
     if max_amount > 0.:
         prob = eitc_claim_prob_scale * c59660 / max_amount
         if credit_claim_urn >= prob:
             c59660 = 0.
+    #
     # Not on the form: filers with credit amount less than eitc_claim_thd
-    # are assumed not to claim (default 0 implies always claim credit amount)
+    # are assumed not to claim
+    # (default eitc_claim_thd=0 implies always claim credit amount)
     if c59660 < eitc_claim_thd:
         c59660 = 0.
 

--- a/taxcalc/cli/input_data_tests/cps-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-25-params.baseline
@@ -1,4 +1,5 @@
 2025 parameter_indexing_CPI_offset 0.0
+2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-25-params.baseline
@@ -1,6 +1,7 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
+2025 actc_claim_prob_scale 9e+99
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-25-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-25-params.reform
@@ -1,4 +1,5 @@
 2025 parameter_indexing_CPI_offset 0.0
+2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-25-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-25-params.reform
@@ -1,6 +1,7 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
+2025 actc_claim_prob_scale 9e+99
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-26-params.baseline
@@ -1,4 +1,5 @@
 2026 parameter_indexing_CPI_offset 0.0
+2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-26-params.baseline
@@ -1,6 +1,7 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
+2026 actc_claim_prob_scale 9e+99
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-26-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-26-params.reform
@@ -1,4 +1,5 @@
 2026 parameter_indexing_CPI_offset 0.0
+2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-26-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-26-params.reform
@@ -1,6 +1,7 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
+2026 actc_claim_prob_scale 9e+99
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-27-params.baseline
@@ -1,6 +1,7 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
+2027 actc_claim_prob_scale 9e+99
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-27-params.baseline
@@ -1,4 +1,5 @@
 2027 parameter_indexing_CPI_offset 0.0
+2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-27-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-27-params.reform
@@ -1,6 +1,7 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
+2027 actc_claim_prob_scale 9e+99
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-27-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-27-params.reform
@@ -1,4 +1,5 @@
 2027 parameter_indexing_CPI_offset 0.0
+2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-28-params.baseline
@@ -1,4 +1,5 @@
 2028 parameter_indexing_CPI_offset 0.0
+2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-28-params.baseline
@@ -1,6 +1,7 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
+2028 actc_claim_prob_scale 9e+99
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-28-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-28-params.reform
@@ -1,4 +1,5 @@
 2028 parameter_indexing_CPI_offset 0.0
+2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-28-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-28-params.reform
@@ -1,6 +1,7 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
+2028 actc_claim_prob_scale 9e+99
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-29-params.baseline
@@ -1,6 +1,7 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
+2029 actc_claim_prob_scale 9e+99
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-29-params.baseline
@@ -1,4 +1,5 @@
 2029 parameter_indexing_CPI_offset 0.0
+2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-29-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-29-params.reform
@@ -1,6 +1,7 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
+2029 actc_claim_prob_scale 9e+99
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-29-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-29-params.reform
@@ -1,4 +1,5 @@
 2029 parameter_indexing_CPI_offset 0.0
+2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-30-params.baseline
@@ -1,6 +1,7 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
+2030 actc_claim_prob_scale 9e+99
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-30-params.baseline
@@ -1,4 +1,5 @@
 2030 parameter_indexing_CPI_offset 0.0
+2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-30-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-30-params.reform
@@ -1,6 +1,7 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
+2030 actc_claim_prob_scale 9e+99
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-30-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-30-params.reform
@@ -1,4 +1,5 @@
 2030 parameter_indexing_CPI_offset 0.0
+2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-31-params.baseline
@@ -1,4 +1,5 @@
 2031 parameter_indexing_CPI_offset 0.0
+2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-31-params.baseline
@@ -1,6 +1,7 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
+2031 actc_claim_prob_scale 9e+99
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-31-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-31-params.reform
@@ -1,4 +1,5 @@
 2031 parameter_indexing_CPI_offset 0.0
+2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-31-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-31-params.reform
@@ -1,6 +1,7 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
+2031 actc_claim_prob_scale 9e+99
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-32-params.baseline
@@ -1,6 +1,7 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
+2032 actc_claim_prob_scale 9e+99
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-32-params.baseline
@@ -1,4 +1,5 @@
 2032 parameter_indexing_CPI_offset 0.0
+2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-32-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-32-params.reform
@@ -1,6 +1,7 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
+2032 actc_claim_prob_scale 9e+99
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-32-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-32-params.reform
@@ -1,4 +1,5 @@
 2032 parameter_indexing_CPI_offset 0.0
+2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-33-params.baseline
@@ -1,6 +1,7 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
+2033 actc_claim_prob_scale 9e+99
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-33-params.baseline
@@ -1,4 +1,5 @@
 2033 parameter_indexing_CPI_offset 0.0
+2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-33-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-33-params.reform
@@ -1,6 +1,7 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
+2033 actc_claim_prob_scale 9e+99
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-33-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-33-params.reform
@@ -1,4 +1,5 @@
 2033 parameter_indexing_CPI_offset 0.0
+2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-34-params.baseline
@@ -1,6 +1,7 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
+2034 actc_claim_prob_scale 9e+99
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-34-params.baseline
@@ -1,4 +1,5 @@
 2034 parameter_indexing_CPI_offset 0.0
+2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-34-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-34-params.reform
@@ -1,6 +1,7 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
+2034 actc_claim_prob_scale 9e+99
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-34-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-34-params.reform
@@ -1,4 +1,5 @@
 2034 parameter_indexing_CPI_offset 0.0
+2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-35-params.baseline
@@ -1,4 +1,5 @@
 2035 parameter_indexing_CPI_offset 0.0
+2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-35-params.baseline
@@ -1,6 +1,7 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
+2035 actc_claim_prob_scale 9e+99
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/cps-35-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-35-params.reform
@@ -1,4 +1,5 @@
 2035 parameter_indexing_CPI_offset 0.0
+2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/cps-35-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-35-params.reform
@@ -1,6 +1,7 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
+2035 actc_claim_prob_scale 9e+99
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.baseline
@@ -1,4 +1,5 @@
 2025 parameter_indexing_CPI_offset 0.0
+2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.baseline
@@ -1,6 +1,7 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
+2025 actc_claim_prob_scale 9e+99
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-25-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.reform
@@ -1,4 +1,5 @@
 2025 parameter_indexing_CPI_offset 0.0
+2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-25-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.reform
@@ -1,6 +1,7 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 9e+99
 2025 eitc_claim_thd 0.0
+2025 actc_claim_prob_scale 9e+99
 2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.baseline
@@ -1,4 +1,5 @@
 2026 parameter_indexing_CPI_offset 0.0
+2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.baseline
@@ -1,6 +1,7 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
+2026 actc_claim_prob_scale 9e+99
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-26-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.reform
@@ -1,4 +1,5 @@
 2026 parameter_indexing_CPI_offset 0.0
+2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-26-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.reform
@@ -1,6 +1,7 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 9e+99
 2026 eitc_claim_thd 0.0
+2026 actc_claim_prob_scale 9e+99
 2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.baseline
@@ -1,6 +1,7 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
+2027 actc_claim_prob_scale 9e+99
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.baseline
@@ -1,4 +1,5 @@
 2027 parameter_indexing_CPI_offset 0.0
+2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-27-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.reform
@@ -1,6 +1,7 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
+2027 actc_claim_prob_scale 9e+99
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-27-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.reform
@@ -1,4 +1,5 @@
 2027 parameter_indexing_CPI_offset 0.0
+2027 eitc_claim_prob_scale 9e+99
 2027 eitc_claim_thd 0.0
 2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.baseline
@@ -1,4 +1,5 @@
 2028 parameter_indexing_CPI_offset 0.0
+2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.baseline
@@ -1,6 +1,7 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
+2028 actc_claim_prob_scale 9e+99
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-28-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.reform
@@ -1,4 +1,5 @@
 2028 parameter_indexing_CPI_offset 0.0
+2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-28-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.reform
@@ -1,6 +1,7 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 9e+99
 2028 eitc_claim_thd 0.0
+2028 actc_claim_prob_scale 9e+99
 2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.baseline
@@ -1,6 +1,7 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
+2029 actc_claim_prob_scale 9e+99
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.baseline
@@ -1,4 +1,5 @@
 2029 parameter_indexing_CPI_offset 0.0
+2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-29-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.reform
@@ -1,6 +1,7 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
+2029 actc_claim_prob_scale 9e+99
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-29-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.reform
@@ -1,4 +1,5 @@
 2029 parameter_indexing_CPI_offset 0.0
+2029 eitc_claim_prob_scale 9e+99
 2029 eitc_claim_thd 0.0
 2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.baseline
@@ -1,6 +1,7 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
+2030 actc_claim_prob_scale 9e+99
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.baseline
@@ -1,4 +1,5 @@
 2030 parameter_indexing_CPI_offset 0.0
+2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-30-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.reform
@@ -1,6 +1,7 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
+2030 actc_claim_prob_scale 9e+99
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-30-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.reform
@@ -1,4 +1,5 @@
 2030 parameter_indexing_CPI_offset 0.0
+2030 eitc_claim_prob_scale 9e+99
 2030 eitc_claim_thd 0.0
 2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.baseline
@@ -1,4 +1,5 @@
 2031 parameter_indexing_CPI_offset 0.0
+2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.baseline
@@ -1,6 +1,7 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
+2031 actc_claim_prob_scale 9e+99
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-31-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.reform
@@ -1,4 +1,5 @@
 2031 parameter_indexing_CPI_offset 0.0
+2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-31-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.reform
@@ -1,6 +1,7 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 9e+99
 2031 eitc_claim_thd 0.0
+2031 actc_claim_prob_scale 9e+99
 2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.baseline
@@ -1,6 +1,7 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
+2032 actc_claim_prob_scale 9e+99
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.baseline
@@ -1,4 +1,5 @@
 2032 parameter_indexing_CPI_offset 0.0
+2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-32-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.reform
@@ -1,6 +1,7 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
+2032 actc_claim_prob_scale 9e+99
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-32-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.reform
@@ -1,4 +1,5 @@
 2032 parameter_indexing_CPI_offset 0.0
+2032 eitc_claim_prob_scale 9e+99
 2032 eitc_claim_thd 0.0
 2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.baseline
@@ -1,6 +1,7 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
+2033 actc_claim_prob_scale 9e+99
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.baseline
@@ -1,4 +1,5 @@
 2033 parameter_indexing_CPI_offset 0.0
+2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-33-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.reform
@@ -1,6 +1,7 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
+2033 actc_claim_prob_scale 9e+99
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-33-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.reform
@@ -1,4 +1,5 @@
 2033 parameter_indexing_CPI_offset 0.0
+2033 eitc_claim_prob_scale 9e+99
 2033 eitc_claim_thd 0.0
 2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.baseline
@@ -1,6 +1,7 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
+2034 actc_claim_prob_scale 9e+99
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.baseline
@@ -1,4 +1,5 @@
 2034 parameter_indexing_CPI_offset 0.0
+2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-34-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.reform
@@ -1,6 +1,7 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
+2034 actc_claim_prob_scale 9e+99
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-34-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.reform
@@ -1,4 +1,5 @@
 2034 parameter_indexing_CPI_offset 0.0
+2034 eitc_claim_prob_scale 9e+99
 2034 eitc_claim_thd 0.0
 2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.baseline
@@ -1,4 +1,5 @@
 2035 parameter_indexing_CPI_offset 0.0
+2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.baseline
@@ -1,6 +1,7 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
+2035 actc_claim_prob_scale 9e+99
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062

--- a/taxcalc/cli/input_data_tests/tmd-35-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.reform
@@ -1,4 +1,5 @@
 2035 parameter_indexing_CPI_offset 0.0
+2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062

--- a/taxcalc/cli/input_data_tests/tmd-35-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.reform
@@ -1,6 +1,7 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 9e+99
 2035 eitc_claim_thd 0.0
+2035 actc_claim_prob_scale 9e+99
 2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -154,6 +154,31 @@
             "cps": true
         }
     },
+    "actc_claim_prob_scale": {
+        "title": "Multiplicative scaling factor applied to ACTC claim probability",
+        "description": "Unscaled claim probability is defined as calculated ACTC amount divided by actc_c*num  for the tax unit.  Default value of 9e99 implies everybody claims their ACTC amount.",
+        "section_1": "",
+        "section_2": "",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 9e+99
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
     "actc_claim_thd": {
         "title": "ACTC claim threshold",
         "description": "ACTC amounts below this threshold are assumed to be unclaimed, and therefore, are zeroed out.  Indexed by wage growth, not price inflation.  Note: 2022 value of 1500 produces plausible ACTC participation with TMD data.",

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -104,6 +104,31 @@
             "cps": true
         }
     },
+    "eitc_claim_prob_scale": {
+        "title": "Multiplicative scaling factor applied to EITC claim probability",
+        "description": "Unscaled claim probability is defined as calculated EITC amount divided by maximum EITC amount for the tax unit.  Default value of 9e99 implies everybody claims their EITC amount.",
+        "section_1": "",
+        "section_2": "",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 9e+99
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 9e+99
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
     "eitc_claim_thd": {
         "title": "EITC claim threshold",
         "description": "EITC amounts below this threshold are assumed to be unclaimed, and therefore, are zeroed out.  Indexed by wage growth, not price inflation.  Note: 2022 value of 1600 produces plausible EITC participation with TMD data.",

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -190,6 +190,9 @@ class Records(Data):
         if not np.all(np.logical_and(np.greater_equal(self.PT_SSTB_income, 0),
                                      np.less_equal(self.PT_SSTB_income, 1))):
             raise ValueError('not all PT_SSTB_income values are 0 or 1')
+        # specify credit_claim_urn so that its values are the same across runs
+        rng = np.random.default_rng(seed=192837465)
+        self.credit_claim_urn[:] = rng.uniform(size=self.MARS.size)
 
     @staticmethod
     def cps_constructor(

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -1,5 +1,11 @@
 {
   "read": {
+    "credit_claim_urn": {
+      "type": "float",
+      "desc": "Uniform random number used in EITC/ACTC claiming logic",
+      "form": {"2013-2016": "internally generated; same across runs"},
+      "availability": ""
+    },
     "DSI": {
       "type": "int",
       "desc": "1 if claimed as dependent on another return; otherwise 0",

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -1,11 +1,5 @@
 {
   "read": {
-    "credit_claim_urn": {
-      "type": "float",
-      "desc": "Uniform random number used in EITC/ACTC claiming logic",
-      "form": {"2013-2016": "internally generated; same across runs"},
-      "availability": ""
-    },
     "DSI": {
       "type": "int",
       "desc": "1 if claimed as dependent on another return; otherwise 0",
@@ -674,6 +668,11 @@
     }
   },
   "calc": {
+    "credit_claim_urn": {
+      "type": "float",
+      "desc": "Uniform random number used in EITC/ACTC claiming logic",
+      "form": {"2013-2016": "internally generated; same across runs"}
+    },
     "niit": {
       "type": "float",
       "desc": "Net Investment Income Tax from Form 8960",

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -506,6 +506,8 @@ def test_EITCamount(test_tuple, expected_value, skip_jit):
 
 
 eitc_claim_thd = 0
+eitc_claim_prob_scale = 9e99
+credit_claim_urn = 0.33
 MARS = 4
 DSI = 0
 c00100 = 19330
@@ -537,7 +539,8 @@ e02300 = 10200
 UI_thd = [150000, 150000, 150000, 150000, 150000]
 UI_em = 10200
 c59660 = 0  # this will be 6660 after the EITC calculation
-tuple1 = (eitc_claim_thd, MARS, DSI, c00100, e00300, e00400, e00600, c01000,
+tuple1 = (eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
+          MARS, DSI, c00100, e00300, e00400, e00600, c01000,
           e02000, e26270, age_head, age_spouse, earned, earned_p, earned_s,
           EIC,
           EITC_ps, EITC_MinEligAge, EITC_MaxEligAge, EITC_ps_addon_MarriedJ,

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -99,7 +99,7 @@ def test_calc_and_used_vars(tests_path):
     for fname in fnames:
         all_cvars.update(set(cvars[fname]))
     # .. add to all_cvars set variables calculated in Records class
-    all_cvars.update(set(['num', 'sep', 'exact']))
+    all_cvars.update(set(['num', 'sep', 'exact', 'credit_claim_urn']))
     # .. add to all_cvars set variables calculated elsewhere
     all_cvars.update(set(['mtr_paytax', 'mtr_inctax']))
     all_cvars.update(set(['benefit_cost_total', 'benefit_value_total']))

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -221,7 +221,7 @@ def test_for_duplicate_names():
         assert varname not in varnames
         varnames.add(varname)
         assert varname in records_varinfo.USABLE_READ_VARS
-    assert num_vars == 211  # number of vars in records_variables.json
+    assert num_vars == 212  # number of vars in records_variables.json
 
 
 def test_records_variables_content(tests_path):

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -366,9 +366,9 @@ def test_ctor_init_with_cps_files():
     surtax
     """, True, 6),  # these 6 variables minus MARS plus RECID
 
-    ('ALL', True, 208),
-    # 208 =
-    # all 211 vars in records_variables.json (see test_records.py)
+    ('ALL', True, 209),
+    # 209 =
+    # all 212 vars in records_variables.json (see test_records.py)
     # minus 5 TaxCalcIO.BASE_DUMPVARS omitting RECID (see taxcalcio.py)
     # plus 2 TaxCalcIO.MTR_DUMPVARS (see taxcalcio.py)
 


### PR DESCRIPTION
This pull request represents step 1 of the two-step development plan described in issue #3080.

See the detailed logic of EITC claiming in section E logic at the end of the **EITC** function in the `calcfunctions.py` module.

See the detailed logic of ACTC claiming at the end of the **AdditionalCTC** function in the `calcfunctions.py` module.
