### PR TITLE
Remove obsolete `eitc_claim_thd` and `actc_claim_thd` parameters

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -3005,7 +3005,7 @@ def EITCamount(basic_frac, phasein_rate, earnings, max_amount,
 
 
 @iterate_jit(nopython=True)
-def EITC(eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
+def EITC(eitc_claim_prob_scale, credit_claim_urn,
          MARS, DSI, c00100, e00300, e00400, e00600, c01000,
          e02000, e26270, age_head, age_spouse, earned, earned_p, earned_s, EIC,
          EITC_ps, EITC_MinEligAge, EITC_MaxEligAge, EITC_ps_addon_MarriedJ,
@@ -3059,9 +3059,6 @@ def EITC(eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
 
     Parameters
     ----------
-    eitc_claim_thd: float
-        Model-specific behavioral parameter: EITC amount below which
-        the credit is assumed unclaimed (no form analogue)
     eitc_claim_prob_scale: float
         See Section E logic and comments (no form analogue)
     credit_claim_urn: float
@@ -3210,20 +3207,10 @@ def EITC(eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
 
     # ---------------- (E) Credit claiming logic ----
     if c59660 > 0.:
-        #
-        # Notice that `eitc_claim_prob_scale` and `eitc_claim_thd` can be used
-        # together to specify non-linear claiming probability schedules.
-        #
         # Not on the form: credit claiming logic that uses claiming probability
         # (eitc_claim_prob_scale=9e99 implies always claim credit)
         prob = eitc_claim_prob_scale * c59660 / max_amount
         if credit_claim_urn >= prob:
-            c59660 = 0.
-        #
-        # Not on the form: filers with credit amount less than eitc_claim_thd
-        # are assumed not to claim
-        # (default eitc_claim_thd=0 implies always claim credit)
-        if c59660 < eitc_claim_thd:
             c59660 = 0.
 
     return c59660
@@ -4259,7 +4246,7 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
 
 
 @iterate_jit(nopython=True)
-def AdditionalCTC(actc_claim_thd, actc_claim_prob_scale, credit_claim_urn,
+def AdditionalCTC(actc_claim_prob_scale, credit_claim_urn,
                   codtc_limited, ACTC_c, n24, earned, ACTC_Income_thd,
                   ACTC_rt, nu06, ACTC_rt_bonus_under6family, ACTC_ChildNum,
                   CTC_is_refundable, CTC_include17, CTC_c,
@@ -4272,9 +4259,6 @@ def AdditionalCTC(actc_claim_thd, actc_claim_prob_scale, credit_claim_urn,
 
     Parameters
     ----------
-    actc_claim_thd: float
-        Model-specific behavioral parameter: ACTC amount below which
-        the credit is assumed unclaimed (no form analogue)
     actc_claim_prob_scale: float
         See logic and comments at bottom of function (no form analogue)
     credit_claim_urn: float
@@ -4374,21 +4358,11 @@ def AdditionalCTC(actc_claim_thd, actc_claim_prob_scale, credit_claim_urn,
 
     # approximate ACTC claiming behavior
     if c11070 > 0.:
-        #
-        # Notice that `actc_claim_prob_scale` and `actc_claim_thd` can be used
-        # together to specify non-linear claiming probability schedules.
-        #
         # Not on the form: credit claiming logic that uses claiming probability
         # (actc_claim_prob_scale=9e99 implies always claim credit)
         max_amount = line17
         prob = actc_claim_prob_scale * c11070 / max_amount
         if credit_claim_urn >= prob:
-            c11070 = 0.
-        #
-        # Not on the form: filers with credit amount less than actc_claim_thd
-        # are assumed not to claim
-        # (default actc_claim_thd=0 implies always claim credit)
-        if c11070 < actc_claim_thd:
             c11070 = 0.
 
     return c11070

--- a/taxcalc/cli/input_data_tests/cps-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-25-params.baseline
@@ -1,8 +1,6 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 1.04
-2025 eitc_claim_thd 0.0
 2025 actc_claim_prob_scale 1.1
-2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062
 2025 SS_Earnings_c 176100.0

--- a/taxcalc/cli/input_data_tests/cps-25-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-25-params.reform
@@ -1,8 +1,6 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 1.04
-2025 eitc_claim_thd 0.0
 2025 actc_claim_prob_scale 1.1
-2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062
 2025 SS_Earnings_c 176100.0

--- a/taxcalc/cli/input_data_tests/cps-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-26-params.baseline
@@ -1,8 +1,6 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 1.04
-2026 eitc_claim_thd 0.0
 2026 actc_claim_prob_scale 1.1
-2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062
 2026 SS_Earnings_c 184500.0

--- a/taxcalc/cli/input_data_tests/cps-26-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-26-params.reform
@@ -1,8 +1,6 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 1.04
-2026 eitc_claim_thd 0.0
 2026 actc_claim_prob_scale 1.1
-2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062
 2026 SS_Earnings_c 184500.0

--- a/taxcalc/cli/input_data_tests/cps-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-27-params.baseline
@@ -1,8 +1,6 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 1.04
-2027 eitc_claim_thd 0.0
 2027 actc_claim_prob_scale 1.1
-2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062
 2027 SS_Earnings_c 190957.5

--- a/taxcalc/cli/input_data_tests/cps-27-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-27-params.reform
@@ -1,8 +1,6 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 1.04
-2027 eitc_claim_thd 0.0
 2027 actc_claim_prob_scale 1.1
-2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062
 2027 SS_Earnings_c 190957.5

--- a/taxcalc/cli/input_data_tests/cps-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-28-params.baseline
@@ -1,8 +1,6 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 1.04
-2028 eitc_claim_thd 0.0
 2028 actc_claim_prob_scale 1.1
-2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062
 2028 SS_Earnings_c 197793.78

--- a/taxcalc/cli/input_data_tests/cps-28-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-28-params.reform
@@ -1,8 +1,6 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 1.04
-2028 eitc_claim_thd 0.0
 2028 actc_claim_prob_scale 1.1
-2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062
 2028 SS_Earnings_c 197793.78

--- a/taxcalc/cli/input_data_tests/cps-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-29-params.baseline
@@ -1,8 +1,6 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 1.04
-2029 eitc_claim_thd 0.0
 2029 actc_claim_prob_scale 1.1
-2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062
 2029 SS_Earnings_c 204558.33

--- a/taxcalc/cli/input_data_tests/cps-29-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-29-params.reform
@@ -1,8 +1,6 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 1.04
-2029 eitc_claim_thd 0.0
 2029 actc_claim_prob_scale 1.1
-2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062
 2029 SS_Earnings_c 204558.33

--- a/taxcalc/cli/input_data_tests/cps-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-30-params.baseline
@@ -1,8 +1,6 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 1.04
-2030 eitc_claim_thd 0.0
 2030 actc_claim_prob_scale 1.1
-2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062
 2030 SS_Earnings_c 211329.21

--- a/taxcalc/cli/input_data_tests/cps-30-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-30-params.reform
@@ -1,8 +1,6 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 1.04
-2030 eitc_claim_thd 0.0
 2030 actc_claim_prob_scale 1.1
-2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062
 2030 SS_Earnings_c 211329.21

--- a/taxcalc/cli/input_data_tests/cps-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-31-params.baseline
@@ -1,8 +1,6 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 1.04
-2031 eitc_claim_thd 0.0
 2031 actc_claim_prob_scale 1.1
-2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062
 2031 SS_Earnings_c 218239.68

--- a/taxcalc/cli/input_data_tests/cps-31-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-31-params.reform
@@ -1,8 +1,6 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 1.04
-2031 eitc_claim_thd 0.0
 2031 actc_claim_prob_scale 1.1
-2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062
 2031 SS_Earnings_c 218239.68

--- a/taxcalc/cli/input_data_tests/cps-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-32-params.baseline
@@ -1,8 +1,6 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 1.04
-2032 eitc_claim_thd 0.0
 2032 actc_claim_prob_scale 1.1
-2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062
 2032 SS_Earnings_c 225223.35

--- a/taxcalc/cli/input_data_tests/cps-32-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-32-params.reform
@@ -1,8 +1,6 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 1.04
-2032 eitc_claim_thd 0.0
 2032 actc_claim_prob_scale 1.1
-2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062
 2032 SS_Earnings_c 225223.35

--- a/taxcalc/cli/input_data_tests/cps-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-33-params.baseline
@@ -1,8 +1,6 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 1.04
-2033 eitc_claim_thd 0.0
 2033 actc_claim_prob_scale 1.1
-2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062
 2033 SS_Earnings_c 232250.32

--- a/taxcalc/cli/input_data_tests/cps-33-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-33-params.reform
@@ -1,8 +1,6 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 1.04
-2033 eitc_claim_thd 0.0
 2033 actc_claim_prob_scale 1.1
-2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062
 2033 SS_Earnings_c 232250.32

--- a/taxcalc/cli/input_data_tests/cps-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-34-params.baseline
@@ -1,8 +1,6 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 1.04
-2034 eitc_claim_thd 0.0
 2034 actc_claim_prob_scale 1.1
-2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062
 2034 SS_Earnings_c 239426.85

--- a/taxcalc/cli/input_data_tests/cps-34-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-34-params.reform
@@ -1,8 +1,6 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 1.04
-2034 eitc_claim_thd 0.0
 2034 actc_claim_prob_scale 1.1
-2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062
 2034 SS_Earnings_c 239426.85

--- a/taxcalc/cli/input_data_tests/cps-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-35-params.baseline
@@ -1,8 +1,6 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 1.04
-2035 eitc_claim_thd 0.0
 2035 actc_claim_prob_scale 1.1
-2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062
 2035 SS_Earnings_c 246849.08

--- a/taxcalc/cli/input_data_tests/cps-35-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-35-params.reform
@@ -1,8 +1,6 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 1.04
-2035 eitc_claim_thd 0.0
 2035 actc_claim_prob_scale 1.1
-2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062
 2035 SS_Earnings_c 246849.08

--- a/taxcalc/cli/input_data_tests/tmd-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.baseline
@@ -1,8 +1,6 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 1.04
-2025 eitc_claim_thd 0.0
 2025 actc_claim_prob_scale 1.1
-2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062
 2025 SS_Earnings_c 176100.0

--- a/taxcalc/cli/input_data_tests/tmd-25-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.reform
@@ -1,8 +1,6 @@
 2025 parameter_indexing_CPI_offset 0.0
 2025 eitc_claim_prob_scale 1.04
-2025 eitc_claim_thd 0.0
 2025 actc_claim_prob_scale 1.1
-2025 actc_claim_thd 0.0
 2025 FICA_ss_trt_employer 0.062
 2025 FICA_ss_trt_employee 0.062
 2025 SS_Earnings_c 176100.0

--- a/taxcalc/cli/input_data_tests/tmd-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.baseline
@@ -1,8 +1,6 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 1.04
-2026 eitc_claim_thd 0.0
 2026 actc_claim_prob_scale 1.1
-2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062
 2026 SS_Earnings_c 184500.0

--- a/taxcalc/cli/input_data_tests/tmd-26-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.reform
@@ -1,8 +1,6 @@
 2026 parameter_indexing_CPI_offset 0.0
 2026 eitc_claim_prob_scale 1.04
-2026 eitc_claim_thd 0.0
 2026 actc_claim_prob_scale 1.1
-2026 actc_claim_thd 0.0
 2026 FICA_ss_trt_employer 0.062
 2026 FICA_ss_trt_employee 0.062
 2026 SS_Earnings_c 184500.0

--- a/taxcalc/cli/input_data_tests/tmd-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.baseline
@@ -1,8 +1,6 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 1.04
-2027 eitc_claim_thd 0.0
 2027 actc_claim_prob_scale 1.1
-2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062
 2027 SS_Earnings_c 190957.5

--- a/taxcalc/cli/input_data_tests/tmd-27-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.reform
@@ -1,8 +1,6 @@
 2027 parameter_indexing_CPI_offset 0.0
 2027 eitc_claim_prob_scale 1.04
-2027 eitc_claim_thd 0.0
 2027 actc_claim_prob_scale 1.1
-2027 actc_claim_thd 0.0
 2027 FICA_ss_trt_employer 0.062
 2027 FICA_ss_trt_employee 0.062
 2027 SS_Earnings_c 190957.5

--- a/taxcalc/cli/input_data_tests/tmd-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.baseline
@@ -1,8 +1,6 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 1.04
-2028 eitc_claim_thd 0.0
 2028 actc_claim_prob_scale 1.1
-2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062
 2028 SS_Earnings_c 197793.78

--- a/taxcalc/cli/input_data_tests/tmd-28-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.reform
@@ -1,8 +1,6 @@
 2028 parameter_indexing_CPI_offset 0.0
 2028 eitc_claim_prob_scale 1.04
-2028 eitc_claim_thd 0.0
 2028 actc_claim_prob_scale 1.1
-2028 actc_claim_thd 0.0
 2028 FICA_ss_trt_employer 0.062
 2028 FICA_ss_trt_employee 0.062
 2028 SS_Earnings_c 197793.78

--- a/taxcalc/cli/input_data_tests/tmd-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.baseline
@@ -1,8 +1,6 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 1.04
-2029 eitc_claim_thd 0.0
 2029 actc_claim_prob_scale 1.1
-2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062
 2029 SS_Earnings_c 204558.33

--- a/taxcalc/cli/input_data_tests/tmd-29-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.reform
@@ -1,8 +1,6 @@
 2029 parameter_indexing_CPI_offset 0.0
 2029 eitc_claim_prob_scale 1.04
-2029 eitc_claim_thd 0.0
 2029 actc_claim_prob_scale 1.1
-2029 actc_claim_thd 0.0
 2029 FICA_ss_trt_employer 0.062
 2029 FICA_ss_trt_employee 0.062
 2029 SS_Earnings_c 204558.33

--- a/taxcalc/cli/input_data_tests/tmd-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.baseline
@@ -1,8 +1,6 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 1.04
-2030 eitc_claim_thd 0.0
 2030 actc_claim_prob_scale 1.1
-2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062
 2030 SS_Earnings_c 211329.21

--- a/taxcalc/cli/input_data_tests/tmd-30-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.reform
@@ -1,8 +1,6 @@
 2030 parameter_indexing_CPI_offset 0.0
 2030 eitc_claim_prob_scale 1.04
-2030 eitc_claim_thd 0.0
 2030 actc_claim_prob_scale 1.1
-2030 actc_claim_thd 0.0
 2030 FICA_ss_trt_employer 0.062
 2030 FICA_ss_trt_employee 0.062
 2030 SS_Earnings_c 211329.21

--- a/taxcalc/cli/input_data_tests/tmd-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.baseline
@@ -1,8 +1,6 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 1.04
-2031 eitc_claim_thd 0.0
 2031 actc_claim_prob_scale 1.1
-2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062
 2031 SS_Earnings_c 218239.68

--- a/taxcalc/cli/input_data_tests/tmd-31-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.reform
@@ -1,8 +1,6 @@
 2031 parameter_indexing_CPI_offset 0.0
 2031 eitc_claim_prob_scale 1.04
-2031 eitc_claim_thd 0.0
 2031 actc_claim_prob_scale 1.1
-2031 actc_claim_thd 0.0
 2031 FICA_ss_trt_employer 0.062
 2031 FICA_ss_trt_employee 0.062
 2031 SS_Earnings_c 218239.68

--- a/taxcalc/cli/input_data_tests/tmd-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.baseline
@@ -1,8 +1,6 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 1.04
-2032 eitc_claim_thd 0.0
 2032 actc_claim_prob_scale 1.1
-2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062
 2032 SS_Earnings_c 225223.35

--- a/taxcalc/cli/input_data_tests/tmd-32-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.reform
@@ -1,8 +1,6 @@
 2032 parameter_indexing_CPI_offset 0.0
 2032 eitc_claim_prob_scale 1.04
-2032 eitc_claim_thd 0.0
 2032 actc_claim_prob_scale 1.1
-2032 actc_claim_thd 0.0
 2032 FICA_ss_trt_employer 0.062
 2032 FICA_ss_trt_employee 0.062
 2032 SS_Earnings_c 225223.35

--- a/taxcalc/cli/input_data_tests/tmd-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.baseline
@@ -1,8 +1,6 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 1.04
-2033 eitc_claim_thd 0.0
 2033 actc_claim_prob_scale 1.1
-2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062
 2033 SS_Earnings_c 232250.32

--- a/taxcalc/cli/input_data_tests/tmd-33-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.reform
@@ -1,8 +1,6 @@
 2033 parameter_indexing_CPI_offset 0.0
 2033 eitc_claim_prob_scale 1.04
-2033 eitc_claim_thd 0.0
 2033 actc_claim_prob_scale 1.1
-2033 actc_claim_thd 0.0
 2033 FICA_ss_trt_employer 0.062
 2033 FICA_ss_trt_employee 0.062
 2033 SS_Earnings_c 232250.32

--- a/taxcalc/cli/input_data_tests/tmd-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.baseline
@@ -1,8 +1,6 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 1.04
-2034 eitc_claim_thd 0.0
 2034 actc_claim_prob_scale 1.1
-2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062
 2034 SS_Earnings_c 239426.85

--- a/taxcalc/cli/input_data_tests/tmd-34-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.reform
@@ -1,8 +1,6 @@
 2034 parameter_indexing_CPI_offset 0.0
 2034 eitc_claim_prob_scale 1.04
-2034 eitc_claim_thd 0.0
 2034 actc_claim_prob_scale 1.1
-2034 actc_claim_thd 0.0
 2034 FICA_ss_trt_employer 0.062
 2034 FICA_ss_trt_employee 0.062
 2034 SS_Earnings_c 239426.85

--- a/taxcalc/cli/input_data_tests/tmd-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.baseline
@@ -1,8 +1,6 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 1.04
-2035 eitc_claim_thd 0.0
 2035 actc_claim_prob_scale 1.1
-2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062
 2035 SS_Earnings_c 246849.08

--- a/taxcalc/cli/input_data_tests/tmd-35-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.reform
@@ -1,8 +1,6 @@
 2035 parameter_indexing_CPI_offset 0.0
 2035 eitc_claim_prob_scale 1.04
-2035 eitc_claim_thd 0.0
 2035 actc_claim_prob_scale 1.1
-2035 actc_claim_thd 0.0
 2035 FICA_ss_trt_employer 0.062
 2035 FICA_ss_trt_employee 0.062
 2035 SS_Earnings_c 246849.08

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -142,14 +142,14 @@ class Policy(Parameters):
         'ALD_AlimonyReceived_hc': (
             'was renamed AlimonyReceived_frac_in_AGI in Tax-Calculator 6.6.0'
         ),
+        # following parameters were removed in PR 3082
+        'eitc_claim_thd': 'was removed in Tax-Calculator 6.7.0',
+        'actc_claim_thd': 'was removed in Tax-Calculator 6.7.0',
     }
     # (2) specify which Policy parameters have been redefined
     REDEFINED_PARAMS = {}
     # (3) specify which Policy parameters are wage (rather than price) indexed
-    WAGE_INDEXED_PARAMS = [
-        'SS_Earnings_c', 'SS_Earnings_thd',
-        'eitc_claim_thd', 'actc_claim_thd'
-    ]
+    WAGE_INDEXED_PARAMS = ['SS_Earnings_c', 'SS_Earnings_thd']
 
     def __init__(self,
                  gfactors=None,

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -129,31 +129,6 @@
             "cps": true
         }
     },
-    "eitc_claim_thd": {
-        "title": "EITC claim threshold",
-        "description": "EITC amounts below this threshold are assumed to be unclaimed, and therefore, are zeroed out.  Indexed by wage growth, not price inflation.  Note: 2022 value of 1600 produces plausible EITC participation with TMD data.",
-        "section_1": "",
-        "section_2": "",
-        "indexable": true,
-        "indexed": true,
-        "type": "float",
-        "value": [
-            {
-                "year": 2013,
-                "value": 0.0
-            }
-        ],
-        "validators": {
-            "range": {
-                "min": 0,
-                "max": 9e+99
-            }
-        },
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        }
-    },
     "actc_claim_prob_scale": {
         "title": "Multiplicative scaling factor applied to ACTC claim probability",
         "description": "Unscaled claim probability is defined as calculated ACTC amount divided by line17 on Schedule 8812 for the tax unit.  Value of 9e99 implies everybody claims their ACTC amount.",
@@ -166,31 +141,6 @@
             {
                 "year": 2013,
                 "value": 1.10
-            }
-        ],
-        "validators": {
-            "range": {
-                "min": 0,
-                "max": 9e+99
-            }
-        },
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        }
-    },
-    "actc_claim_thd": {
-        "title": "ACTC claim threshold",
-        "description": "ACTC amounts below this threshold are assumed to be unclaimed, and therefore, are zeroed out.  Indexed by wage growth, not price inflation.  Note: 2022 value of 1500 produces plausible ACTC participation with TMD data.",
-        "section_1": "",
-        "section_2": "",
-        "indexable": true,
-        "indexed": true,
-        "type": "float",
-        "value": [
-            {
-                "year": 2013,
-                "value": 0.0
             }
         ],
         "validators": {

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -505,7 +505,6 @@ def test_EITCamount(test_tuple, expected_value, skip_jit):
     assert np.allclose(test_value, expected_value)
 
 
-eitc_claim_thd = 0
 eitc_claim_prob_scale = 9e99
 credit_claim_urn = 0.33
 MARS = 4
@@ -539,7 +538,7 @@ e02300 = 10200
 UI_thd = [150000, 150000, 150000, 150000, 150000]
 UI_em = 10200
 c59660 = 0  # this will be 6660 after the EITC calculation
-tuple1 = (eitc_claim_thd, eitc_claim_prob_scale, credit_claim_urn,
+tuple1 = (eitc_claim_prob_scale, credit_claim_urn,
           MARS, DSI, c00100, e00300, e00400, e00600, c01000,
           e02000, e26270, age_head, age_spouse, earned, earned_p, earned_s,
           EIC,


### PR DESCRIPTION
These parameters are no longer needed given the enhancements in PR #3079 and PR #3081.