### PR TITLE
Prevent negative AGI from reducing standard deduction

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -1689,7 +1689,7 @@ def StdDed(DSI, earned, STD, age_head, age_spouse, STD_Aged, STD_Dep,
     # current law; active in 2020-2021 and under reforms).
     # ----------------------------------------------------------------
     if STD_allow_charity_ded_nonitemizers:
-        capped_ded = min(e19800, ID_Charity_crt_all * c00100)
+        capped_ded = min(e19800, ID_Charity_crt_all * max(0., c00100))
         standard += min(capped_ded, STD_charity_ded_nonitemizers_max[MARS - 1])
     return standard
 

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -205,7 +205,9 @@ tuple8 = (1, 200, STD_in, 44, 0, STD_Aged_in, 1000, 350, 3, 0, 0, 0, 2,
           True, 0, 100000, 1, Charity_max_in)
 tuple9 = (1, 1000, STD_in, 44, 0, STD_Aged_in, 1000, 350, 3, 0, 0, 0, 2,
           True, 0, 100000, 1, Charity_max_in)
-expected = [12000, 15800, 13800, 14400, 6000, 6000, 0, 1000, 1350]
+tuple10 = (0, 1000, STD_in, 44, 0, STD_Aged_in, 1000, 350, 1, 0, 0, 0, 2,
+           True, 0, 1, -3000, Charity_max_in)
+expected = [12000, 15800, 13800, 14400, 6000, 6000, 0, 1000, 1350, 6000]
 
 
 @pytest.mark.stded
@@ -215,12 +217,13 @@ expected = [12000, 15800, 13800, 14400, 6000, 6000, 0, 1000, 1350]
         (tuple3, expected[2]), (tuple4, expected[3]),
         (tuple5, expected[4]), (tuple6, expected[5]),
         (tuple7, expected[6]), (tuple8, expected[7]),
-        (tuple9, expected[8])], ids=[
+        (tuple9, expected[8]), (tuple10, expected[9])], ids=[
             'Married, young', 'Married, allow charity',
             'Married, allow charity, over limit',
             'Married, two old', 'Single 1', 'Single 2', 'Married, Single',
             'Marrid, Single, dep, under earn',
-            'Married, Single, dep, over earn'])
+            'Married, Single, dep, over earn',
+            'Single, negative AGI'])
 def test_StdDed(test_tuple, expected_value, skip_jit):
     """
     Tests the StdDed function


### PR DESCRIPTION
## Summary

An initial approach to resolving the bug reported in issue #3090.

This prevents a negative AGI from turning the nonitemizer charitable deduction cap into a negative amount that reduces the standard deduction.

## Root Cause

`StdDed` computes the reform/legacy CARES nonitemizer charitable contribution cap as:

```python
ID_Charity_crt_all * c00100
```

When `c00100` is negative, that cap is negative. The subsequent `min(...)` calls can then add a negative amount to `standard`, reducing the standard deduction even when cash charitable contributions are zero.

The itemized charitable deduction path already applies charitable percentage limits to positive AGI. This PR applies the same positive-AGI floor in the nonitemizer standard-deduction add-on.

## Validation

- `env -u UV_FROZEN uv run --python 3.13 --with pytest --with-editable . python -m pytest taxcalc/tests/test_calcfunctions.py -q -m stded`
- `env -u UV_FROZEN uv run --python 3.13 --with pytest --with-editable . python -m pytest taxcalc/tests/test_calcfunctions.py -q`
- `env -u UV_FROZEN uv run --python 3.13 --with pycodestyle --with-editable . python -m pycodestyle taxcalc/calcfunctions.py taxcalc/tests/test_calcfunctions.py`
- Manual one-row calculator reproducer: 2026 single filer with `c00100 = -3000` now has `standard = 16100`, matching the same filer with `c00100 = 0`.
