### PR TITLE
Add parameter for AMT tax rate on unrecaptured Section 1250 gains

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -2404,7 +2404,7 @@ def AMT(e07300, dwks13, standard, f6251, c00100, c18300, taxbc,
         AMT_em, AMT_prt, AMT_rt1, AMT_rt2_addon,
         AMT_child_em, AMT_em_ps, AMT_em_pe,
         AMT_CG_brk1, AMT_CG_brk2, AMT_CG_brk3, AMT_CG_rt1, AMT_CG_rt2,
-        AMT_CG_rt3, AMT_CG_rt4, c05800, c09600, c62100):
+        AMT_CG_rt3, AMT_CG_rt4, AMT_CG_rt1250, c05800, c09600, c62100):
     """
     Computes Form 6251 (2025) Alternative Minimum Tax (AMT).
 
@@ -2536,6 +2536,8 @@ def AMT(e07300, dwks13, standard, f6251, c00100, c18300, taxbc,
     AMT_CG_rt4: float
         Reform-only long term capital gain and qualified dividends
         (AMT) rate 4
+    AMT_CG_rt1250: float
+        Unrecaptured Section 1250 gain (AMT) rate
     f6251: int
         1 if Form 6251 (AMT) attached to return, otherwise 0
     e62900: float
@@ -2647,10 +2649,11 @@ def AMT(e07300, dwks13, standard, f6251, c00100, c18300, taxbc,
             linex2 = max(0., line30 - linex1)
         cgtax3 = line33 * AMT_CG_rt3           # line 34 = 20% * line 33
         cgtax4 = linex2 * AMT_CG_rt4
-        if line14 == 0.:                       # line 35-37: §1250 25%
+        if line14 == 0.:                       # line 35-37: §1250 taxation
             line37 = 0.
         else:
-            line37 = 0.25 * max(0., line6 - line17 - line32 - line33 - linex2)
+            line36 = max(0., line6 - line17 - line32 - line33 - linex2)
+            line37 = AMT_CG_rt1250 * line36
         line38 = line18 + cgtax1 + cgtax2 + cgtax3 + cgtax4 + line37
         line40 = min(flat_rate_tax, line38)    # min(line 38, line 39)
         line7 = line40

--- a/taxcalc/cli/input_data_tests/cps-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-25-params.baseline
@@ -108,6 +108,7 @@
 2025 AMT_CG_rt3 0.2
 2025 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2025 AMT_CG_rt4 1.0
+2025 AMT_CG_rt1250 0.25
 2025 CG_nodiff False
 2025 CG_ec 0.0
 2025 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-25-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-25-params.reform
@@ -108,6 +108,7 @@
 2025 AMT_CG_rt3 0.2
 2025 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2025 AMT_CG_rt4 1.0
+2025 AMT_CG_rt1250 0.25
 2025 CG_nodiff False
 2025 CG_ec 0.0
 2025 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-26-params.baseline
@@ -108,6 +108,7 @@
 2026 AMT_CG_rt3 0.2
 2026 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2026 AMT_CG_rt4 1.0
+2026 AMT_CG_rt1250 0.25
 2026 CG_nodiff False
 2026 CG_ec 0.0
 2026 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-26-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-26-params.reform
@@ -108,6 +108,7 @@
 2026 AMT_CG_rt3 0.2
 2026 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2026 AMT_CG_rt4 1.0
+2026 AMT_CG_rt1250 0.25
 2026 CG_nodiff False
 2026 CG_ec 0.0
 2026 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-27-params.baseline
@@ -108,6 +108,7 @@
 2027 AMT_CG_rt3 0.2
 2027 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2027 AMT_CG_rt4 1.0
+2027 AMT_CG_rt1250 0.25
 2027 CG_nodiff False
 2027 CG_ec 0.0
 2027 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-27-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-27-params.reform
@@ -108,6 +108,7 @@
 2027 AMT_CG_rt3 0.2
 2027 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2027 AMT_CG_rt4 1.0
+2027 AMT_CG_rt1250 0.25
 2027 CG_nodiff False
 2027 CG_ec 0.0
 2027 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-28-params.baseline
@@ -108,6 +108,7 @@
 2028 AMT_CG_rt3 0.2
 2028 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2028 AMT_CG_rt4 1.0
+2028 AMT_CG_rt1250 0.25
 2028 CG_nodiff False
 2028 CG_ec 0.0
 2028 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-28-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-28-params.reform
@@ -108,6 +108,7 @@
 2028 AMT_CG_rt3 0.2
 2028 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2028 AMT_CG_rt4 1.0
+2028 AMT_CG_rt1250 0.25
 2028 CG_nodiff False
 2028 CG_ec 0.0
 2028 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-29-params.baseline
@@ -108,6 +108,7 @@
 2029 AMT_CG_rt3 0.2
 2029 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2029 AMT_CG_rt4 1.0
+2029 AMT_CG_rt1250 0.25
 2029 CG_nodiff False
 2029 CG_ec 0.0
 2029 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-29-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-29-params.reform
@@ -108,6 +108,7 @@
 2029 AMT_CG_rt3 0.2
 2029 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2029 AMT_CG_rt4 1.0
+2029 AMT_CG_rt1250 0.25
 2029 CG_nodiff False
 2029 CG_ec 0.0
 2029 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-30-params.baseline
@@ -108,6 +108,7 @@
 2030 AMT_CG_rt3 0.2
 2030 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2030 AMT_CG_rt4 1.0
+2030 AMT_CG_rt1250 0.25
 2030 CG_nodiff False
 2030 CG_ec 0.0
 2030 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-30-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-30-params.reform
@@ -108,6 +108,7 @@
 2030 AMT_CG_rt3 0.2
 2030 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2030 AMT_CG_rt4 1.0
+2030 AMT_CG_rt1250 0.25
 2030 CG_nodiff False
 2030 CG_ec 0.0
 2030 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-31-params.baseline
@@ -108,6 +108,7 @@
 2031 AMT_CG_rt3 0.2
 2031 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2031 AMT_CG_rt4 1.0
+2031 AMT_CG_rt1250 0.25
 2031 CG_nodiff False
 2031 CG_ec 0.0
 2031 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-31-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-31-params.reform
@@ -108,6 +108,7 @@
 2031 AMT_CG_rt3 0.2
 2031 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2031 AMT_CG_rt4 1.0
+2031 AMT_CG_rt1250 0.25
 2031 CG_nodiff False
 2031 CG_ec 0.0
 2031 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-32-params.baseline
@@ -108,6 +108,7 @@
 2032 AMT_CG_rt3 0.2
 2032 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2032 AMT_CG_rt4 1.0
+2032 AMT_CG_rt1250 0.25
 2032 CG_nodiff False
 2032 CG_ec 0.0
 2032 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-32-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-32-params.reform
@@ -108,6 +108,7 @@
 2032 AMT_CG_rt3 0.2
 2032 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2032 AMT_CG_rt4 1.0
+2032 AMT_CG_rt1250 0.25
 2032 CG_nodiff False
 2032 CG_ec 0.0
 2032 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-33-params.baseline
@@ -108,6 +108,7 @@
 2033 AMT_CG_rt3 0.2
 2033 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2033 AMT_CG_rt4 1.0
+2033 AMT_CG_rt1250 0.25
 2033 CG_nodiff False
 2033 CG_ec 0.0
 2033 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-33-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-33-params.reform
@@ -108,6 +108,7 @@
 2033 AMT_CG_rt3 0.2
 2033 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2033 AMT_CG_rt4 1.0
+2033 AMT_CG_rt1250 0.25
 2033 CG_nodiff False
 2033 CG_ec 0.0
 2033 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-34-params.baseline
@@ -108,6 +108,7 @@
 2034 AMT_CG_rt3 0.2
 2034 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2034 AMT_CG_rt4 1.0
+2034 AMT_CG_rt1250 0.25
 2034 CG_nodiff False
 2034 CG_ec 0.0
 2034 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-34-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-34-params.reform
@@ -108,6 +108,7 @@
 2034 AMT_CG_rt3 0.2
 2034 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2034 AMT_CG_rt4 1.0
+2034 AMT_CG_rt1250 0.25
 2034 CG_nodiff False
 2034 CG_ec 0.0
 2034 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/cps-35-params.baseline
@@ -108,6 +108,7 @@
 2035 AMT_CG_rt3 0.2
 2035 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2035 AMT_CG_rt4 1.0
+2035 AMT_CG_rt1250 0.25
 2035 CG_nodiff False
 2035 CG_ec 0.0
 2035 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/cps-35-params.reform
+++ b/taxcalc/cli/input_data_tests/cps-35-params.reform
@@ -108,6 +108,7 @@
 2035 AMT_CG_rt3 0.2
 2035 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2035 AMT_CG_rt4 1.0
+2035 AMT_CG_rt1250 0.25
 2035 CG_nodiff False
 2035 CG_ec 0.0
 2035 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-25-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.baseline
@@ -108,6 +108,7 @@
 2025 AMT_CG_rt3 0.2
 2025 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2025 AMT_CG_rt4 1.0
+2025 AMT_CG_rt1250 0.25
 2025 CG_nodiff False
 2025 CG_ec 0.0
 2025 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-25-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-25-params.reform
@@ -108,6 +108,7 @@
 2025 AMT_CG_rt3 0.2
 2025 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2025 AMT_CG_rt4 1.0
+2025 AMT_CG_rt1250 0.25
 2025 CG_nodiff False
 2025 CG_ec 0.0
 2025 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-26-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.baseline
@@ -108,6 +108,7 @@
 2026 AMT_CG_rt3 0.2
 2026 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2026 AMT_CG_rt4 1.0
+2026 AMT_CG_rt1250 0.25
 2026 CG_nodiff False
 2026 CG_ec 0.0
 2026 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-26-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-26-params.reform
@@ -108,6 +108,7 @@
 2026 AMT_CG_rt3 0.2
 2026 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2026 AMT_CG_rt4 1.0
+2026 AMT_CG_rt1250 0.25
 2026 CG_nodiff False
 2026 CG_ec 0.0
 2026 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-27-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.baseline
@@ -108,6 +108,7 @@
 2027 AMT_CG_rt3 0.2
 2027 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2027 AMT_CG_rt4 1.0
+2027 AMT_CG_rt1250 0.25
 2027 CG_nodiff False
 2027 CG_ec 0.0
 2027 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-27-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-27-params.reform
@@ -108,6 +108,7 @@
 2027 AMT_CG_rt3 0.2
 2027 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2027 AMT_CG_rt4 1.0
+2027 AMT_CG_rt1250 0.25
 2027 CG_nodiff False
 2027 CG_ec 0.0
 2027 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-28-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.baseline
@@ -108,6 +108,7 @@
 2028 AMT_CG_rt3 0.2
 2028 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2028 AMT_CG_rt4 1.0
+2028 AMT_CG_rt1250 0.25
 2028 CG_nodiff False
 2028 CG_ec 0.0
 2028 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-28-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-28-params.reform
@@ -108,6 +108,7 @@
 2028 AMT_CG_rt3 0.2
 2028 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2028 AMT_CG_rt4 1.0
+2028 AMT_CG_rt1250 0.25
 2028 CG_nodiff False
 2028 CG_ec 0.0
 2028 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-29-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.baseline
@@ -108,6 +108,7 @@
 2029 AMT_CG_rt3 0.2
 2029 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2029 AMT_CG_rt4 1.0
+2029 AMT_CG_rt1250 0.25
 2029 CG_nodiff False
 2029 CG_ec 0.0
 2029 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-29-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-29-params.reform
@@ -108,6 +108,7 @@
 2029 AMT_CG_rt3 0.2
 2029 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2029 AMT_CG_rt4 1.0
+2029 AMT_CG_rt1250 0.25
 2029 CG_nodiff False
 2029 CG_ec 0.0
 2029 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-30-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.baseline
@@ -108,6 +108,7 @@
 2030 AMT_CG_rt3 0.2
 2030 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2030 AMT_CG_rt4 1.0
+2030 AMT_CG_rt1250 0.25
 2030 CG_nodiff False
 2030 CG_ec 0.0
 2030 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-30-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-30-params.reform
@@ -108,6 +108,7 @@
 2030 AMT_CG_rt3 0.2
 2030 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2030 AMT_CG_rt4 1.0
+2030 AMT_CG_rt1250 0.25
 2030 CG_nodiff False
 2030 CG_ec 0.0
 2030 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-31-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.baseline
@@ -108,6 +108,7 @@
 2031 AMT_CG_rt3 0.2
 2031 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2031 AMT_CG_rt4 1.0
+2031 AMT_CG_rt1250 0.25
 2031 CG_nodiff False
 2031 CG_ec 0.0
 2031 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-31-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-31-params.reform
@@ -108,6 +108,7 @@
 2031 AMT_CG_rt3 0.2
 2031 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2031 AMT_CG_rt4 1.0
+2031 AMT_CG_rt1250 0.25
 2031 CG_nodiff False
 2031 CG_ec 0.0
 2031 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-32-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.baseline
@@ -108,6 +108,7 @@
 2032 AMT_CG_rt3 0.2
 2032 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2032 AMT_CG_rt4 1.0
+2032 AMT_CG_rt1250 0.25
 2032 CG_nodiff False
 2032 CG_ec 0.0
 2032 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-32-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-32-params.reform
@@ -108,6 +108,7 @@
 2032 AMT_CG_rt3 0.2
 2032 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2032 AMT_CG_rt4 1.0
+2032 AMT_CG_rt1250 0.25
 2032 CG_nodiff False
 2032 CG_ec 0.0
 2032 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-33-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.baseline
@@ -108,6 +108,7 @@
 2033 AMT_CG_rt3 0.2
 2033 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2033 AMT_CG_rt4 1.0
+2033 AMT_CG_rt1250 0.25
 2033 CG_nodiff False
 2033 CG_ec 0.0
 2033 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-33-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-33-params.reform
@@ -108,6 +108,7 @@
 2033 AMT_CG_rt3 0.2
 2033 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2033 AMT_CG_rt4 1.0
+2033 AMT_CG_rt1250 0.25
 2033 CG_nodiff False
 2033 CG_ec 0.0
 2033 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-34-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.baseline
@@ -108,6 +108,7 @@
 2034 AMT_CG_rt3 0.2
 2034 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2034 AMT_CG_rt4 1.0
+2034 AMT_CG_rt1250 0.25
 2034 CG_nodiff False
 2034 CG_ec 0.0
 2034 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-34-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-34-params.reform
@@ -108,6 +108,7 @@
 2034 AMT_CG_rt3 0.2
 2034 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2034 AMT_CG_rt4 1.0
+2034 AMT_CG_rt1250 0.25
 2034 CG_nodiff False
 2034 CG_ec 0.0
 2034 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-35-params.baseline
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.baseline
@@ -108,6 +108,7 @@
 2035 AMT_CG_rt3 0.2
 2035 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2035 AMT_CG_rt4 1.0
+2035 AMT_CG_rt1250 0.25
 2035 CG_nodiff False
 2035 CG_ec 0.0
 2035 CG_reinvest_ec_rt 0.0

--- a/taxcalc/cli/input_data_tests/tmd-35-params.reform
+++ b/taxcalc/cli/input_data_tests/tmd-35-params.reform
@@ -108,6 +108,7 @@
 2035 AMT_CG_rt3 0.2
 2035 AMT_CG_brk3 [9.e+99 9.e+99 9.e+99 9.e+99 9.e+99]
 2035 AMT_CG_rt4 1.0
+2035 AMT_CG_rt1250 0.25
 2035 CG_nodiff False
 2035 CG_ec 0.0
 2035 CG_reinvest_ec_rt 0.0

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -12460,6 +12460,31 @@
             "cps": false
         }
     },
+    "AMT_CG_rt1250": {
+        "title": "Unrecaptured Section 1250 gain (AMT) rate",
+        "description": "Unrecaptured Section 1250 gain (Form 6251 line 36) is taxed at this rate under the AMT maximum-capital-gains computation.",
+        "section_1": "Capital Gains And Dividends",
+        "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.25
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
     "CG_nodiff": {
         "title": "Long term capital gains and qualified dividends taxed no differently than regular taxable income",
         "description": "Specifies whether or not long term capital gains and qualified dividends are taxed like regular taxable income.",


### PR DESCRIPTION
Fixes #2635.
No measurable change in income tax results.