### PR TITLE
Fix table-construction bug reported in issue #2460

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -549,6 +549,26 @@ def test_add_quantile_trow_var():
                                               100, decile_details=True)
 
 
+def test_add_quantile_trow_var_cut_error():
+    """
+    Test the fix for the Pandas cut() error reported in Tax-Calculator
+    Github issue #2460.  When more than 10% of the weighted filing units
+    have non-positive income_measure and decile_details=True, the bottom
+    decile subdivision used to produce non-monotonic bin_edges, which
+    caused the pd.cut() call in add_quantile_table_row_variable() to raise
+    a 'bins must increase monotonically' ValueError.  The function must
+    now produce the full set of decile-detail rows without raising.
+    """
+    edata = [-1.0] * 3 + list(range(1, 21))  # 3 non-positive + 20 positive
+    weights = [100.0] * 3 + [10.0] * 20  # non-positive units have >10% weight
+    dfx = pd.DataFrame({'expanded_income': edata, 's006': weights})
+    dfb = add_quantile_table_row_variable(dfx, 'expanded_income',
+                                          10, decile_details=True)
+    assert 'table_row' in dfb
+    # decile_details adds four extra rows to the ten deciles
+    assert set(dfb['table_row'].unique()).issubset(set(range(1, 15)))
+
+
 def test_dist_table_sum_row(cps_subsample):
     """Test docstring"""
     rec = Records.cps_constructor(data=cps_subsample)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -227,6 +227,16 @@ def add_quantile_table_row_variable(dframe, income_measure, num_quantiles,
         bin_edges.insert(-1, bin_edges[-2] + 0.5 * bin_width)  # top of 90-95
         bin_edges.insert(-1, bin_edges[-2] + 0.4 * bin_width)  # top of 95-99
         num_bins += 4
+        # When the weight of the filing units with non-positive income_measure
+        # exceeds one decile, the top-of-negatives and top-of-zeros edges
+        # inserted above can exceed a following decile edge, making bin_edges
+        # non-monotonic and causing pd.cut() to raise a ValueError (see
+        # Tax-Calculator issue #2460).  Nudge any non-increasing edge up to the
+        # smallest float greater than the prior edge so that bin_edges are
+        # strictly increasing (any bin thereby emptied contributes a zero row).
+        for idx in range(1, len(bin_edges)):
+            if bin_edges[idx] <= bin_edges[idx - 1]:
+                bin_edges[idx] = np.nextafter(bin_edges[idx - 1], np.inf)
     labels = range(1, (num_bins + 1))
     dframe['table_row'] = pd.cut(dframe['cumsum_temp'], bin_edges,
                                  right=False, labels=labels)


### PR DESCRIPTION
Fixes #2460 by adding a test (in `test_utils.py`) that fails without the bug fix, and then adding code to the `add_quantile_table_row_variable` function (in `utils.py`) that avoids the failure of the new test without changing any other test results.
