### PR TITLE
Add --jsonparams option to Tax-Calculator CLI, `tc`

### DIFF
--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -41,7 +41,7 @@ def cli_tc_main():
         ),
         (
             '          '
-            '[--params] [--tables] [--graphs] '
+            '[--params] [--jsonparams] [--tables] [--graphs] '
             '[--dumpdb] [--dumpvars DUMPVARS]\n'
         ),
         (
@@ -110,6 +110,12 @@ def cli_tc_main():
                         help=('optional flag that causes policy parameter '
                               'values for baseline and reform to be written '
                               'to separate text files.'),
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--jsonparams',
+                        help=('optional flag that causes the policy parameter '
+                              'files written by the --params option to use '
+                              'JSON format rather than text format.'),
                         default=False,
                         action='store_true')
     parser.add_argument('--tables',
@@ -248,6 +254,16 @@ def cli_tc_main():
             sys.stderr.write(msg)
             sys.stderr.write('USAGE: tc --help\n')
         return 1
+    # check args.params and args.jsonparams consistency
+    if not args.params and args.jsonparams:
+        msg = 'ERROR: --jsonparams option specified without --params option\n'
+        if using_error_file:
+            with open(efilename, 'w', encoding='utf-8') as efile:
+                efile.write(msg)
+        else:
+            sys.stderr.write(msg)
+            sys.stderr.write('USAGE: tc --help\n')
+        return 1
     # specify dumpvars_str from args.dumpvars file
     dumpvars_str = ''
     if args.dumpvars:
@@ -332,6 +348,7 @@ def cli_tc_main():
         return 1
     tcio.analyze(
         output_params=args.params,
+        output_jsonparams=args.jsonparams,
         output_tables=args.tables,
         output_graphs=args.graphs,
         output_dump=args.dumpdb,
@@ -353,6 +370,7 @@ def cli_tc_main():
         tcio.advance_to_year(taxyear + xyear)
         tcio.analyze(
             output_params=args.params,
+            output_jsonparams=args.jsonparams,
             output_tables=args.tables,
             output_graphs=args.graphs,
             output_dump=args.dumpdb,

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -8,6 +8,7 @@ Tax-Calculator Input-Output class.
 import os
 import gc
 import copy
+import json
 import sqlite3
 from pathlib import Path
 import numpy as np
@@ -434,6 +435,7 @@ class TaxCalcIO():
     def analyze(
             self,
             output_params=False,
+            output_jsonparams=False,
             output_tables=False,
             output_graphs=False,
             output_dump=False,
@@ -447,6 +449,10 @@ class TaxCalcIO():
         output_params: boolean
            whether or not to write baseline and reform policy parameter
            values to separate text files
+
+        output_jsonparams: boolean
+           whether the baseline and reform policy parameter files written
+           when output_params is True use JSON format rather than text format
 
         output_tables: boolean
            whether or not to generate and write distributional tables
@@ -471,9 +477,9 @@ class TaxCalcIO():
         # pylint: disable=too-many-arguments,too-many-positional-arguments
         # pylint: disable=too-many-branches,too-many-locals
         doing_calcs = output_tables or output_graphs or output_dump
-        # optionally write --params output to text files
+        # optionally write --params output files
         if output_params:
-            self.write_policy_params_files()
+            self.write_policy_params_files(output_jsonparams)
         if not doing_calcs:
             return
         # do output calculations
@@ -525,12 +531,14 @@ class TaxCalcIO():
                 mtr_ptax_bas, mtr_itax_bas,
             )
 
-    def write_policy_params_files(self):
+    def write_policy_params_files(self, jsonparams=False):
         """
         Write baseline and reform policy parameter values to separate files.
         """
-        self._write_params(self.calc_bas, '-params.baseline', 'baseline')
-        self._write_params(self.calc_ref, '-params.reform', 'reform')
+        self._write_params(self.calc_bas, '-params.baseline', 'baseline',
+                           jsonparams)
+        self._write_params(self.calc_ref, '-params.reform', 'reform',
+                           jsonparams)
 
     BASE_DUMPVARS = [
         'RECID',
@@ -738,16 +746,29 @@ class TaxCalcIO():
                 br_dump[vname].to_numpy(dtype=vdtype, copy=True)
             )
 
-    def _write_params(self, calc, ext, label):
+    def _write_params(self, calc, ext, label, jsonparams=False):
         """
         Write policy parameter values from calc to the ext output file.
         """
         year = calc.current_year
         fname = self.output_filename.replace('.xxx', ext)
-        with open(fname, 'w', encoding='utf-8') as pfile:
+        if jsonparams:
+            pdict = {}
             for pname in Policy.parameter_list():
                 pval = calc.policy_param(pname)
-                pfile.write(f'{year} {pname} {pval}\n')
+                if isinstance(pval, np.ndarray):
+                    pval = pval.tolist()
+                elif isinstance(pval, np.generic):
+                    pval = pval.item()
+                pdict[pname] = {year: pval}
+            with open(fname, 'w', encoding='utf-8') as pfile:
+                json.dump(pdict, pfile, indent=4)
+                pfile.write('\n')
+        else:
+            with open(fname, 'w', encoding='utf-8') as pfile:
+                for pname in Policy.parameter_list():
+                    pval = calc.policy_param(pname)
+                    pfile.write(f'{year} {pname} {pval}\n')
         if not self.silent:
             print(  # pragma: no cover
                 f'Write {label} policy parameter values to file {fname}'

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -8,6 +8,7 @@ Tests for Tax-Calculator TaxCalcIO class.
 # pylint: disable=too-many-lines
 
 import os
+import json
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -505,6 +506,42 @@ def test_write_policy_param_files(reformfile1):
         filepath = outfilepath.replace('.xxx', ext)
         if os.path.isfile(filepath):
             os.remove(filepath)
+
+
+def test_write_json_policy_param_files(reformfile1):
+    """
+    Test write_policy_params_files with jsonparams=True.
+    """
+    taxyear = 2021
+    tcio = TaxCalcIO(
+        input_data=pd.read_csv(StringIO(RAWINPUT)),
+        tax_year=taxyear,
+        baseline=None,
+        reform=reformfile1.name,
+        assump=None,
+        behavior=None,
+    )
+    assert not tcio.errmsg
+    tcio.init(input_data=pd.read_csv(StringIO(RAWINPUT)),
+              tax_year=taxyear,
+              baseline=None,
+              reform=reformfile1.name,
+              assump=None,
+              behavior=None,
+              exact_calculations=False)
+    assert not tcio.errmsg
+    tcio.write_policy_params_files(jsonparams=True)
+    for ext in ['-params.baseline', '-params.reform']:
+        filepath = tcio.output_filename.replace('.xxx', ext)
+        assert os.path.isfile(filepath)
+        with open(filepath, 'r', encoding='utf-8') as pfile:
+            pdict = json.load(pfile)
+        # each parameter maps to a dict containing its year and value
+        assert isinstance(pdict, dict)
+        assert len(pdict) > 0
+        for pval in pdict.values():
+            assert set(pval.keys()) == {f'{taxyear}'}
+        os.remove(filepath)
 
 
 def test_no_tables_or_graphs(reformfile1):


### PR DESCRIPTION
Fixes #2610.

When specifying this new option on the command line (along with the old --params option) the parameters output files (for baseline and reform policies) will be written in JSON (rather than simple text) format.   This enhancement makes it easy to generate a JSON file containing a comprehensive description of current-law policy in any year.

Here is an example of using (and testing) this new CLI feature for a past year:
```
> tc cps.csv 2014 --params --jsonparams --tables --runid 1
Read input data for 2014; input data were extrapolated to 2014
Write baseline policy parameter values to file run1-14-params.baseline
Write reform policy parameter values to file run1-14-params.reform
Write tabular output to file run1-14.tables
Execution time is 10.3 seconds
> cp run1-14-params.baseline clp14.json
> head clp14.json ; tail clp14.json
{
    "parameter_indexing_CPI_offset": {
        "2014": 0.0
    },
    "eitc_claim_prob_scale": {
        "2014": 1.03
    },
    "eitc_claim_prob_min": {
        "2014": 0.4
    },
    "BEN_oasdi_repeal": {
        "2014": false
    },
    "BEN_ui_repeal": {
        "2014": false
    },
    "BEN_other_repeal": {
        "2014": false
    }
}
> tc cps.csv 2014 --baseline clp14.json --tables --runid 2
Read input data for 2014; input data were extrapolated to 2014
Write tabular output to file run2-14.tables
Execution time is 12.2 seconds
> diff run2-14.tables run1-14.tables 
> 
```

The same thing can be done for a future year.
