### PR TITLE
Require mcp 2.0.0+ package for the model-use agent

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - curl
     - openpyxl
     - behresp
-    - "mcp[cli]"
+    - "mcp[cli]>=2.0.0"
 
   run:
     - "python>=3.11, <3.14"
@@ -29,7 +29,7 @@ requirements:
     - curl
     - openpyxl
     - behresp
-    - "mcp[cli]"
+    - "mcp[cli]>=2.0.0"
 
 test:
   commands:

--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,4 @@ dependencies:
 - pip:
     - "jupyter-book<2.0"
     - "paramtools>=0.20.0"
-    - "mcp[cli]"
+    - "mcp[cli]>=2.0.0"


### PR DESCRIPTION
The Tax-Calculator Assistant (TCA), which enables conversational use of the Tax-Calculator CLI via Claude Code and nearly thirty custom-developed Model Context Protocol (MCP) tools, now uses `mcp` pacakge >= 2.0.0.  

The TCA **model-use agent** is currently located in a private Github repo.

The **structural-enhancement agent** for developing Tax-Calculator code changes necessary to analyze reforms not parameterized on the Tax-Calculator master branch is currently being developed in this public Github repo.
