### PR TITLE
Add interest-paid credit structural enhancement

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -4049,6 +4049,48 @@ def CharityCredit(e19800, e20100, c00100, CR_Charity_rt, CR_Charity_f,
 
 
 @iterate_jit(nopython=True)
+def InterestPaidCredit(e19200, CR_InterestPaid_rt, intpaid_credit):
+    """
+    Computes credit for interest paid (a reform construct with no IRS
+    form correspondence; not part of current-law policy).  Under
+    current law `CR_InterestPaid_rt` defaults to 0.0, so
+    `intpaid_credit` is identically 0 and the function is inert.
+
+    Under reform the credit equals
+        CR_InterestPaid_rt * e19200
+    where `e19200` is the input variable for itemizable interest paid.
+    Because the base is the input variable rather than the `ItemDed`
+    output `c19200`, the credit is available to every filing unit with
+    interest paid, whether or not it itemizes deductions, and it is
+    unaffected by the `ID_InterestPaid_hc` haircut and the
+    `ID_InterestPaid_c` cap.
+
+    Downstream consumers: `intpaid_credit` is fed to
+    `NonrefundableCredits`, where it is sequentially limited against
+    the remaining tax-before-credits (`avail`) unless the reform-only
+    `CR_InterestPaid_refundable` switch is true, in which case the
+    credit is left unlimited there and is added on the refundable side
+    in `IITAX`.
+
+    Parameters
+    ----------
+    e19200: float
+        Itemizable interest paid (Sch A line 15)
+    CR_InterestPaid_rt: float
+        Interest paid credit rate (reform-only; 0 under current law)
+    intpaid_credit: float
+        Records-bound output, computed below.
+
+    Returns
+    -------
+    intpaid_credit: float
+        Credit for interest paid
+    """
+    intpaid_credit = CR_InterestPaid_rt * max(0., e19200)
+    return intpaid_credit
+
+
+@iterate_jit(nopython=True)
 def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
                          e07600, p08000, odc,
                          personal_nonrefundable_credit,
@@ -4056,6 +4098,7 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
                          CR_RetirementSavings_hc, CR_ForeignTax_hc,
                          CR_ResidentialEnergy_hc, CR_GeneralBusiness_hc,
                          CR_MinimumTax_hc, CR_OtherCredits_hc, charity_credit,
+                         intpaid_credit, CR_InterestPaid_refundable,
                          c07180, c07200, c07220, c07230, c07240,
                          c07260, c07300, c07400, c07600, c08000):
     """
@@ -4078,7 +4121,10 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
           -> PrYrMin -> SchR -> Other); unmodeled on-form items are
           5b, 6c, 6e-6m
       (D) Reform-only nonrefundable credits (charity_credit,
-          personal_nonrefundable_credit); inert under current law
+          intpaid_credit, personal_nonrefundable_credit); inert under
+          current law.  The intpaid_credit capping is skipped under
+          reform-only `CR_InterestPaid_refundable`, which routes that
+          credit to the refundable side in `IITAX`
 
     CTC/ODC placement between Sch 3 line 4 and line 5a is consistent
     with Sch 8812 Credit Limit Worksheet A, which subtracts only Sch 3
@@ -4092,7 +4138,7 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
         applied here, then `min` against remaining tax.  All `CR_*_hc`
         parameters default to 0.0 (current-law inert).
       * **Pre-computed credits** `c07180`, `c07200`, `c07220`,
-        `c07230`, `odc`, `charity_credit`,
+        `c07230`, `odc`, `charity_credit`, `intpaid_credit`,
         `personal_nonrefundable_credit`: the source function already
         applied any haircut and its own Credit Limit Worksheet; this
         function re-caps against remaining tax (belt-and-braces, and
@@ -4104,7 +4150,8 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
     `ChildDepTaxCredit` (which produces `c07220` and `odc`) and the
     other per-credit source functions (`F2441` -> `c07180`,
     `EducationTaxCredit` -> `c07230`, `SchR` -> `c07200`,
-    `CharityCredit` -> `charity_credit`, `PersonalTaxCredit` ->
+    `CharityCredit` -> `charity_credit`, `InterestPaidCredit` ->
+    `intpaid_credit`, `PersonalTaxCredit` ->
     `personal_nonrefundable_credit`), and before `AdditionalCTC` /
     `C1040`.
 
@@ -4163,6 +4210,13 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
     charity_credit: float
         Reform-only nonrefundable charity credit from `CharityCredit`;
         current-law inert
+    intpaid_credit: float
+        Reform-only interest paid credit from `InterestPaidCredit`;
+        current-law inert
+    CR_InterestPaid_refundable: bool
+        Reform-only switch (default false): when true, the interest
+        paid credit is not limited here and is routed to the
+        refundable side in `IITAX`
     c07180: float
         Credit for child and dependent care expenses from Form 2441
         (Sch 3 line 2); pre-computed by `F2441`
@@ -4219,6 +4273,9 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
         Limited other nonrefundable credits (Sch 3 line 6z)
     charity_credit: float
         Limited reform-only nonrefundable charity credit
+    intpaid_credit: float
+        Limited reform-only interest paid credit; unchanged when
+        `CR_InterestPaid_refundable`
     personal_nonrefundable_credit: float
         Limited reform-only personal nonrefundable credit
     """
@@ -4282,13 +4339,16 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
     # (D) Reform-only nonrefundable credits (current-law inert)
     charity_credit = min(max(0., charity_credit), avail)
     avail = avail - charity_credit
+    if not CR_InterestPaid_refundable:
+        intpaid_credit = min(max(0., intpaid_credit), avail)
+        avail = avail - intpaid_credit
     personal_nonrefundable_credit = min(
         max(0., personal_nonrefundable_credit), avail
     )
     avail = avail - personal_nonrefundable_credit
     return (c07180, c07200, c07220, c07230, c07240, odc,
             c07260, c07300, c07400, c07600, c08000, charity_credit,
-            personal_nonrefundable_credit)
+            intpaid_credit, personal_nonrefundable_credit)
 
 
 @iterate_jit(nopython=True)
@@ -4421,8 +4481,9 @@ def AdditionalCTC(actc_claim_prob_min, actc_claim_prob_scale, credit_claim_urn,
 def C1040(c05800, c07180, c07200, c07220, c07230, c07240, c07260, c07300,
           c07400, c07600, c08000, e09700, e09800, e09900, niit, setax,
           ptax_amc, othertaxes, c07100, c09200, odc, charity_credit,
-          personal_nonrefundable_credit,
-          CTC_is_refundable, ODC_is_refundable):
+          intpaid_credit, personal_nonrefundable_credit,
+          CTC_is_refundable, ODC_is_refundable,
+          CR_InterestPaid_refundable):
     """
     Assembles Form 1040 (2025) lines 22-24 + Schedule 2 (2025) Part II
     line 21:
@@ -4468,6 +4529,10 @@ def C1040(c05800, c07180, c07200, c07220, c07230, c07240, c07260, c07300,
       * `ODC_is_refundable` -- when true, ODC (`odc`) is excluded
         from `c07100` here and `NonrefundableCredits` skips ODC
         capping; ODC is routed to the refundable side via `IITAX`.
+      * `CR_InterestPaid_refundable` -- when true, the interest paid
+        credit (`intpaid_credit`) is excluded from `c07100` here and
+        `NonrefundableCredits` skips its capping; the credit is routed
+        to the refundable side via `IITAX`.
 
     Calling order (calculator.py): invoked after `NonrefundableCredits`
     and `AdditionalCTC` (so each per-credit input has had its final
@@ -4539,6 +4604,8 @@ def C1040(c05800, c07180, c07200, c07220, c07230, c07240, c07260, c07300,
         `ODC_is_refundable`
     charity_credit: float
         Reform-only nonrefundable charity credit (current-law inert)
+    intpaid_credit: float
+        Reform-only interest paid credit (current-law inert)
     personal_nonrefundable_credit: float
         Reform-only personal nonrefundable credit (current-law inert)
     CTC_is_refundable: bool
@@ -4547,6 +4614,10 @@ def C1040(c05800, c07180, c07200, c07220, c07230, c07240, c07260, c07300,
     ODC_is_refundable: bool
         Reform-only switch (default false): when true, ODC is routed
         to the refundable side rather than included in `c07100`
+    CR_InterestPaid_refundable: bool
+        Reform-only switch (default false): when true, the interest
+        paid credit is routed to the refundable side rather than
+        included in `c07100`
 
     Returns
     -------
@@ -4576,6 +4647,8 @@ def C1040(c05800, c07180, c07200, c07220, c07230, c07240, c07260, c07300,
               + c07260                              # Sch 3 line 5a ResEnergy
               + odc * (1. - ODC_is_refundable)      # 1040 line 19 ODC
               + charity_credit                      # reform-only
+              + intpaid_credit * (
+                  1. - CR_InterestPaid_refundable)  # reform-only
               + personal_nonrefundable_credit)      # reform-only
     # (B) Form 1040 (2025) line 22 = max(0, line 18 - line 21):
     # tax remaining after nonrefundable credits applied.
@@ -4738,6 +4811,7 @@ def CTC_new(CTC_new_c, CTC_new_rt, CTC_new_c_under6_bonus,
 def IITAX(c59660, c11070, c10960, personal_refundable_credit, ctc_new, rptc,
           c09200, CDCC_refund, recovery_rebate_credit,
           eitc, c07220, odc, CTC_is_refundable, ODC_is_refundable,
+          intpaid_credit, CR_InterestPaid_refundable,
           soi_iitax, setax, e09800, ptax_amc, refund,
           ctc_total, ctc_refundable, ctc_nonrefundable,
           iitax, payrolltax, combined):
@@ -4757,11 +4831,13 @@ def IITAX(c59660, c11070, c10960, personal_refundable_credit, ctc_new, rptc,
 
     Body sections:
 
-      (A) Reform-only refundable conversions. When `CTC_is_refundable` or
-          `ODC_is_refundable` are true (both default false under current
-          law), the CTC (c07220) and ODC (odc) amounts that were applied
-          as nonrefundable credits in `NonrefundableCredits` / `C1040` are
-          added on the refundable side here.
+      (A) Reform-only refundable conversions. When `CTC_is_refundable`,
+          `ODC_is_refundable`, or `CR_InterestPaid_refundable` are true
+          (all default false under current law), the CTC (c07220), ODC
+          (odc), and interest paid credit (intpaid_credit) amounts that
+          would otherwise be applied as nonrefundable credits in
+          `NonrefundableCredits` / `C1040` are added on the refundable
+          side here.
       (B) Form 1040 line 32 build. Each addend is annotated with its 1040
           line (27a EIC / 28 ACTC / 29 AOC / 30 historical RRC / 31 Sch 3
           line 13 refundable CDCC) or reform-only label (no form line).
@@ -4836,6 +4912,14 @@ def IITAX(c59660, c11070, c10960, personal_refundable_credit, ctc_new, rptc,
     ODC_is_refundable: bool
         Reform-only switch (default false): when true, ODC is treated as
         refundable (`odc` is added to `refund` here)
+    intpaid_credit: float
+        Reform-only interest paid credit from `InterestPaidCredit`
+        (no Form 1040 line; default 0 under current law)
+    CR_InterestPaid_refundable: bool
+        Reform-only switch (default false): when true, the interest paid
+        credit is treated as refundable (`intpaid_credit` is added to
+        `refund` here rather than being applied against tax in
+        `NonrefundableCredits` / `C1040`)
     soi_iitax: bool
         Bucketing switch: when true, `setax`, `e09800`, and `ptax_amc`
         remain in `iitax` via `c09200` (SOI/IRS concept, matching the
@@ -4900,6 +4984,7 @@ def IITAX(c59660, c11070, c10960, personal_refundable_credit, ctc_new, rptc,
     # (A) reform-only refundable conversions of CTC / ODC
     ctc_refund = c07220 if CTC_is_refundable else 0.
     odc_refund = odc if ODC_is_refundable else 0.
+    intpaid_refund = intpaid_credit if CR_InterestPaid_refundable else 0.
     # (B) Form 1040 line 32: refundable-credit sum
     refund = (eitc +                       # Form 1040 line 27a (EIC)
               c11070 +                     # Form 1040 line 28 (ACTC)
@@ -4910,7 +4995,8 @@ def IITAX(c59660, c11070, c10960, personal_refundable_credit, ctc_new, rptc,
               ctc_new +                     # reform-only (no form line)
               rptc +                        # reform-only (no form line)
               ctc_refund +                  # reform-only (CTC_is_refundable)
-              odc_refund)                   # reform-only (ODC_is_refundable)
+              odc_refund +                  # reform-only (ODC_is_refundable)
+              intpaid_refund)               # reform-only (CR_InterestPaid_*)
     # (C) records-bound CTC diagnostic (not on the form)
     ctc_total = c07220 + c11070 + odc + ctc_new
     ctc_refundable = ctc_refund + c11070 + odc_refund + ctc_new

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -21,7 +21,7 @@ from taxcalc.calcfunctions import (TaxInc, SchXYZTax, GainsTax, AGIsurtax,
                                    ChildDepTaxCredit, AdditionalCTC, CTC_new,
                                    PersonalTaxCredit, SchR,
                                    AmOppCreditParts, EducationTaxCredit,
-                                   CharityCredit,
+                                   CharityCredit, InterestPaidCredit,
                                    NonrefundableCredits, C1040, IITAX,
                                    FairShareTax, LumpSumTax, BenefitPrograms,
                                    ExpandIncome, AfterTaxIncome)
@@ -1446,6 +1446,7 @@ class Calculator():
         SchR(self.__policy, self.__records)
         EducationTaxCredit(self.__policy, self.__records)
         CharityCredit(self.__policy, self.__records)
+        InterestPaidCredit(self.__policy, self.__records)
         ChildDepTaxCredit(self.__policy, self.__records)
         NonrefundableCredits(self.__policy, self.__records)
         AdditionalCTC(self.__policy, self.__records)

--- a/taxcalc/policy_current_law.json
+++ b/taxcalc/policy_current_law.json
@@ -23343,6 +23343,56 @@
             "cps": true
         }
     },
+    "CR_InterestPaid_rt": {
+        "title": "Interest Paid Credit rate",
+        "description": "If greater than zero, this decimal fraction represents the portion of interest paid provided as a tax credit.  Credit claimed will be rt*e19200, which is available to all filing units whether or not they itemize deductions.",
+        "section_1": "",
+        "section_2": "",
+        "indexable": false,
+        "indexed": false,
+        "type": "float",
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.0
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
+    "CR_InterestPaid_refundable": {
+        "title": "Whether the interest paid credit is refundable",
+        "description": "If true, the interest paid credit is fully refundable; if false, the credit is nonrefundable.",
+        "section_1": "",
+        "section_2": "",
+        "indexable": false,
+        "indexed": false,
+        "type": "bool",
+        "value": [
+            {
+                "year": 2013,
+                "value": false
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": false,
+                "max": true
+            }
+        },
+        "compatible_data": {
+            "puf": true,
+            "cps": true
+        }
+    },
     "SeniorDed_c": {
         "title": "Senior deduction amount per elderly head/spouse",
         "description": "Senior deduction is capped at this level per elderly head/spouse.",

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -1059,6 +1059,11 @@
       "desc": "Credit for charitable giving",
       "form": {"2013-20??": "calculated variable"}
     },
+    "intpaid_credit": {
+      "type": "float",
+      "desc": "Credit for interest paid",
+      "form": {"2013-20??": "calculated variable"}
+    },
     "dwks10": {
       "type": "float",
       "desc": "search taxcalc/calcfunctions.py for how calculated and used",

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -1122,3 +1122,77 @@ def test_SchXYZ():
         brks[4], brks[5], brks[6])
     print(f'Actual value returned from SchXYZ function = {actual:.2f}')
     assert np.allclose(actual, expect), f'{actual:.2f} != {expect:.2f}'
+
+
+@pytest.mark.parametrize(
+    'e19200,rate,expect',
+    [(20_000.0, 0.0, 0.0),      # current-law rate ==> inert
+     (20_000.0, 0.10, 2_000.0),  # 0.10 * 20_000
+     (0.0, 0.10, 0.0),          # no interest paid ==> no credit
+     (-500.0, 0.10, 0.0)]       # negative interest paid guarded to zero
+)
+def test_InterestPaidCredit(e19200, rate, expect, skip_jit):
+    """
+    Tests the InterestPaidCredit function, whose credit is the product
+    of the CR_InterestPaid_rt rate and non-negative interest paid.
+    """
+    actual = calcfunctions.InterestPaidCredit(e19200, rate, 0.0)
+    assert np.allclose(actual, expect)
+
+
+@pytest.mark.parametrize('refundable', [False, True])
+def test_intpaid_credit_flow(refundable, skip_jit):
+    """
+    Tests the flow of the interest paid credit through the
+    NonrefundableCredits, C1040, and IITAX functions for a filing unit
+    that has $1_000 of tax before credits, $20_000 of interest paid,
+    a CR_InterestPaid_rt of 0.10, and no other credits or other taxes.
+
+    Expected results computed independently of the calcfunctions code:
+      credit = 0.10 * 20_000 = 2_000
+      when NOT refundable:
+        credit is limited to the 1_000 of tax before credits, so
+        c07100 = 1_000 and c09200 = max(0, 1_000 - 1_000) + 0 = 0
+        refund = 0 and iitax = 0 - 0 = 0
+      when refundable:
+        credit is not limited and is excluded from c07100, so
+        c07100 = 0 and c09200 = max(0, 1_000 - 0) + 0 = 1_000
+        refund = 2_000 and iitax = 1_000 - 2_000 = -1_000
+    """
+    tax = 1_000.0
+    credit = calcfunctions.InterestPaidCredit(20_000.0, 0.10, 0.0)
+    assert np.allclose(credit, 2_000.0)
+    # limit nonrefundable credits against tax before credits; returns
+    # (c07180, c07200, c07220, c07230, c07240, odc, c07260, c07300,
+    #  c07400, c07600, c08000, charity_credit, intpaid_credit,
+    #  personal_nonrefundable_credit)
+    nrc = calcfunctions.NonrefundableCredits(
+        tax, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        False, False,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        credit, refundable,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    assert np.allclose(nrc[12], 2_000.0 if refundable else 1_000.0)
+    # assemble Form 1040 lines 21-24; returns (c07100, othertaxes, c09200)
+    f1040 = calcfunctions.C1040(
+        tax, nrc[0], nrc[1], nrc[2], nrc[3], nrc[4], nrc[6], nrc[7],
+        nrc[8], nrc[9], nrc[10], 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, nrc[5], nrc[11],
+        nrc[12], nrc[13],
+        False, False, refundable)
+    assert np.allclose(f1040[1], 0.0)
+    assert np.allclose(f1040[0], 0.0 if refundable else 1_000.0)
+    assert np.allclose(f1040[2], 1_000.0 if refundable else 0.0)
+    # net refundable credits out of tax liability; returned tuple is
+    # (eitc, refund, ctc_total, ctc_refundable, ctc_nonrefundable,
+    #  iitax, payrolltax, combined)
+    iit = calcfunctions.IITAX(
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        f1040[2], 0.0, 0.0,
+        0.0, nrc[2], nrc[5], False, False,
+        nrc[12], refundable,
+        True, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0)
+    assert np.allclose(iit[1], 2_000.0 if refundable else 0.0)
+    assert np.allclose(iit[5], -1_000.0 if refundable else 0.0)

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -221,7 +221,7 @@ def test_for_duplicate_names():
         assert varname not in varnames
         varnames.add(varname)
         assert varname in records_varinfo.USABLE_READ_VARS
-    assert num_vars == 212  # number of vars in records_variables.json
+    assert num_vars == 213  # number of vars in records_variables.json
 
 
 def test_records_variables_content(tests_path):

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -367,9 +367,9 @@ def test_ctor_init_with_cps_files():
     surtax
     """, True, 6),  # these 6 variables minus MARS plus RECID
 
-    ('ALL', True, 209),
-    # 209 =
-    # all 212 vars in records_variables.json (see test_records.py)
+    ('ALL', True, 210),
+    # 210 =
+    # all 213 vars in records_variables.json (see test_records.py)
     # minus 5 TaxCalcIO.BASE_DUMPVARS omitting RECID (see taxcalcio.py)
     # plus 2 TaxCalcIO.MTR_DUMPVARS (see taxcalcio.py)
 


### PR DESCRIPTION
**This PR was created for documentation purposes only.**

_See below the following commit text for details on how this PR was generated._

### Claude-generated commit text:

---

Add two reform-only policy parameters, CR_InterestPaid_rt (default 0.0) and CR_InterestPaid_refundable (default false), and a new calculated variable, intpaid_credit, so the model can simulate a credit for interest paid.

The new InterestPaidCredit function computes the credit as CR_InterestPaid_rt * max(0, e19200), using the input variable rather than the ItemDed output c19200 so that the credit is available to all filing units whether or not they itemize deductions.

When CR_InterestPaid_refundable is false, NonrefundableCredits limits the credit against remaining tax liability and C1040 includes it in c07100.  When true, that capping is skipped, C1040 excludes the credit from c07100, and IITAX adds it to refund -- the same routing pattern used by CTC_is_refundable and ODC_is_refundable.

Both parameters default to current-law-inert values, so results under current law and under already-parameterized reforms are unchanged. The two hardcoded records_variables.json counts in test_records.py and test_taxcalcio.py are updated for the added variable.

---

### PR creation details:
* hand creation of `intpaid-credit` branch off master branch (after merge of PR #3115)
* start Claude Code using `claude --model opus --effort medium` command
* initial prompt and Claude's responses are [here](https://claude.ai/code/artifact/c5832221-a286-4726-86e4-e40afd8d9d1a)
* session cost information is:
  Total cost:            $3.94
  Total duration (API):  5m 35s
  Total duration (wall): 20m 24s
  Total code changes:    159 lines added, 17 lines removed
  Usage by model:
      claude-haiku-4-5:  561 input, 18 output, 0 cache read, 0 cache write ($0.0007)
         claude-opus-5:  2.6k input, 21.8k output, 5.1m cache read, 82.0k cache write ($3.94)
                              
  Current session
  ████                                               8% used
  Resets 8:10pm (America/Toronto)
 
NOTE: the "8% used" is a fraction of the Claude Pro account's rolling five-hour quota/limit.
A Claude Pro account costs $17 per month and there are no additional charges as long as optional over-limit charges are turned off (so the $3.94 cost mentioned above is not relevant).
