### PR TITLE
Modify cli/input_data_tests/tests.sh so it skips the TMD input data test if TMD files are not present

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,13 +78,14 @@ below.
   `respy`; do not rely on its last line alone, since collection errors
   and crashes are reported differently from test failures.
   
-- `make brtest > resbr 2>&1` and, if tmd data files are present,
-  `make idtest > resid 2>&1` — CLI tests. Both always exit zero, so
-  check them with `grep -Ei 'differ|error|traceback' resbr resid`; any
-  output means failure.  The `idtest` requires `tmd.csv`,
-  `tmd_weights.csv.gz`, and `tmd_growfactors.csv` in the top-level
-  repo folder. `pytest-all` uninstalls the local package that `brtest`
-  and `idtest` build and install, so run `pytest-all` before them.
+- `make brtest > resbr 2>&1` and `make idtest > resid 2>&1` — CLI tests.
+  Both always exit zero, so check them using this command:
+  `grep -Ei 'differ|error|traceback' resbr resid`; any output means failure.
+  The `idtest` skips the TMD input data test if `tmd.csv`,
+  `tmd_weights.csv.gz`, and `tmd_growfactors.csv` are not present in
+  the top-level repo folder. `pytest-all` uninstalls the local package
+  that `brtest` and `idtest` build and install, so run `pytest-all`
+  before them.
 
 The `rescs`, `respy`, `resbr`, and `resid` files are not git-ignored;
 delete them when done, and check `git status` for stray test output

--- a/taxcalc/cli/input_data_tests/tests.sh
+++ b/taxcalc/cli/input_data_tests/tests.sh
@@ -14,6 +14,10 @@ for yr in {25..35}; do
 done
 
 # use TMD input files
+if ! [[ -f ../../../tmd.csv ]]; then
+    echo "Skipping TMD input data test" >&2
+    exit 0
+fi
 tc ../../../tmd.csv 2025 --numyears 11 --exact --tables --silent
 for yr in {25..35}; do
     diff -q tmd-$yr-#-#-#-#.tables tmd-$yr.tables

--- a/taxcalc/cli/input_data_tests/tests.sh
+++ b/taxcalc/cli/input_data_tests/tests.sh
@@ -18,6 +18,14 @@ if ! [[ -f ../../../tmd.csv ]]; then
     echo "Skipping TMD input data test" >&2
     exit 0
 fi
+if ! [[ -f ../../../tmd_weights.csv.gz ]]; then
+    echo "Skipping TMD input data test" >&2
+    exit 0
+fi
+if ! [[ -f ../../../tmd_growfactors.csv ]]; then
+    echo "Skipping TMD input data test" >&2
+    exit 0
+fi
 tc ../../../tmd.csv 2025 --numyears 11 --exact --tables --silent
 for yr in {25..35}; do
     diff -q tmd-$yr-#-#-#-#.tables tmd-$yr.tables

--- a/taxcalc/structural-enhancement.md
+++ b/taxcalc/structural-enhancement.md
@@ -67,12 +67,7 @@ inconsistencies among `calcfunctions.py`, `calculator.py`,
 `policy_current_law.json`, and `records_variables.json` without
 incurring the cost of the slower test commands.
 
-And execute the fast "pytest . -m param_var_count" command as well.
-
-Also, confirm that the three national TMD files (`tmd.csv`,
-`tmd_weights.csv.gz`, and `tmd_growfactors.csv`) are in the top-level
-repo folder, where they are ignored by git version control.  The idtest
-command cannot run without them.
+And also execute the fast "pytest . -m param_var_count" command.
 
 Then execute the following test commands, in the order listed, until
 they all pass.  If a test command fails, return to step 3 revising
@@ -92,8 +87,8 @@ the other commands.
     diagnose the failure; do not rely on the last line of respy alone,
     because collection errors and crashes are reported differently from
     test failures)
-- Execute the "make brtest > resbr 2>&1" command and then, if the three
-  TMD files are available, the "make idtest > resid 2>&1" command
+- Execute the "make brtest > resbr 2>&1" command and then the
+  "make idtest > resid 2>&1" command
   * Both these commands execute shell scripts that report mismatches but
     always exit with a zero status, so check their output by executing
     the "grep -Ei 'differ|error|traceback' resbr resid" command


### PR DESCRIPTION
And revise `taxcalc/structural-enhancement.md` workflow to always include "make idtest" as part of the testing step.