### PR TITLE
Revise Makefile

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash -l {0}
         working-directory: ./
         run: |
-          pytest -m 'not requires_puf and not requires_tmd and not local' -nauto --cov=./ --cov-report=xml
+          pytest -m 'not local' -nauto --cov=./ --cov-report=xml
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/Tax-Calculator')
@@ -43,6 +43,5 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          #fail_ci_if_error: true
           fail_ci_if_error: false
           verbose: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ below.
 - `make cstest > rescs 2>&1` — coding-style checks; fails if `rescs`
   is not empty.
 
-- `make pytest-all > respy 2>&1 ; echo EXIT=$?` - full test suite;
+- `make pytest > respy 2>&1 ; echo EXIT=$?` - full unit test suite;
   fails if the EXIT value is not zero. Diagnose failures by consulting
   `respy`; do not rely on its last line alone, since collection errors
   and crashes are reported differently from test failures.
@@ -83,13 +83,13 @@ below.
   `grep -Ei 'differ|error|traceback' resbr resid`; any output means failure.
   The `idtest` skips the TMD input data test if `tmd.csv`,
   `tmd_weights.csv.gz`, and `tmd_growfactors.csv` are not present in
-  the top-level repo folder. `pytest-all` uninstalls the local package
-  that `brtest` and `idtest` build and install, so run `pytest-all`
+  the top-level repo folder. `pytest` uninstalls the local package
+  that `brtest` and `idtest` build and install, so run `pytest`
   before them.
 
 The `rescs`, `respy`, `resbr`, and `resid` files are not git-ignored;
 delete them when done, and check `git status` for stray test output
-such as `df-??-#-*` files left behind by an aborted `pytest-all` run.
+such as `df-??-#-*` files left behind by an aborted `pytest` run.
 
 Never revise a test, or a file containing expected test results, in
 order to make a failing test pass without first asking the user for

--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,23 @@
 help:
 	@echo "USAGE: make [TARGET]"
 	@echo "TARGETS:"
-	@echo "help       : show help message"
+	@echo "help       : show this help message"
+	@echo "package    : build and install local taxcalc package"
 	@echo "clean      : remove .pyc files and local taxcalc package"
-	@echo "package    : build and install local package"
-	@echo "pytest     : generate report for and cleanup after"
-	@echo "             pytest -m 'not reforms2 and not requires_puf and not requires_tmd'"
-	@echo "pytest-all : generate report for and cleanup after"
-	@echo "             pytest -m ''"
-	@echo "tctest     : generate report for and cleanup after"
-	@echo "             tc --test"
-	@echo "tctest-jit : generate report for and cleanup after"
-	@echo "             tc --test when environment var NOTAXCALCJIT is set"
 	@echo "cstest     : generate coding-style errors using the"
-	@echo "             pycodestyle (nee pep8) and pylint tools"
+	@echo "             pycodestyle and pylint tools"
+	@echo "pytest     : generate report for and cleanup after"
+	@echo "             pytest -m ''"
 	@echo "brtest     : generate report for and cleanup after executing"
 	@echo "             taxcalc/cli/behavioral_responses_tests/tests.sh"
 	@echo "idtest     : generate report for and cleanup after executing"
 	@echo "             taxcalc/cli/input_data_tests/tests.sh"
-	@echo "coverage   : generate test coverage report"
+	@echo "tctest     : generate report for and cleanup after"
+	@echo "             tc --test"
+	@echo "tctest-jit : generate report for and cleanup after"
+	@echo "             tc --test when environment var NOTAXCALCJIT is set"
+	@echo "tests      : execute cstest, pytest, brtest, idtest"
+	@echo "coverage   : generate pytest coverage report"
 	@echo "git-sync   : synchronize local, origin, and upstream Git repos"
 	@echo "git-pr N=n : create local pr-n branch containing upstream PR"
 
@@ -48,12 +47,7 @@ endef
 
 .PHONY=pytest
 pytest: clean
-	@cd taxcalc ; pytest -n6 --durations=0 --durations-min=15 -m "not reforms2 and not requires_puf and not requires_tmd"
-	@$(pytest-cleanup)
-
-.PHONY=pytest
-pytest-all: clean
-	@cd taxcalc ; pytest -n6 --durations=0 --durations-min=15 -m ""
+	@cd taxcalc ; pytest -n6 --durations=0 --durations-min=15
 	@$(pytest-cleanup)
 
 define tctest-cleanup
@@ -96,6 +90,9 @@ brtest: package
 idtest: package
 	@echo "Executing taxcalc/cli/input_data_tests"
 	@cd taxcalc/cli/input_data_tests ; ./tests.sh
+
+.PHONY=tests
+tests: clean cstest pytest brtest idtest
 
 define coverage-cleanup
 rm -f .coverage .coverage.* htmlcov/*

--- a/docs/contributing/RELEASING.md
+++ b/docs/contributing/RELEASING.md
@@ -13,10 +13,7 @@ In the top-level Tax-Calculator directory, do the following:
 --> on branch X-Y-Z, edit docs/about/releases.md to finalize X.Y.Z info
 --> specify release X.Y.Z in setup.py, taxcalc/__init__.py, docs/index.md
 --> run `python update_pcl.py`  [to update policy_current_law.json]
---> run `make cstest`  [to confirm project coding style is being followed]
---> run `make pytest-all`  [to confirm all pytest test are passing]
---> run `make brtest`  [to check CLI results for behavioral responses]
---> run `make idtest`  [to check CLI results for CPS and TMD input data]
+--> run `make tests `  [executes cstest, pytest, brtest, idtest]
 --> run `make tctest-jit`  [to ensure JIT decorators are not hiding bugs]
 --> commit X-Y-Z branch and push to origin
 --> open new GitHub pull request using your X-Y-Z branch

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -19,56 +19,12 @@ There are two phases of testing: testing that the source code
 complies with the Tax-Calculator coding style and testing that
 the source code does not contain bugs.
 
-## Testing coding style
-
-The Tax-Calculator project follows `pycodestyle` and `pylint`
-recommended coding style in most cases.
-
-Check that your changes on a local branch are coding-style compliant
-by running the coding-style test in the top-level Tax-Calculator
-directory as follows:
-
+You can execute both phases of testing with a single command:
 ```
-make cstest
+make tests
 ```
 
-No messages indicate the tests pass.  Fix any warnings.  When you pass
-all these coding-style tests, proceed to the second phase of testing.
-
-## Testing with pytest
-
-There are two variants of this second testing phase depending on
-whether or not you have access to the PUF-related and TMD-related
-input data files.
-
-**NO PUF AND NO TMD**: If you do not have access to the PUF or TMD
-input data files, run the second-phase of testing as follows at the
-command prompt in the Tax-Calculator directory:
-
-```
-make pytest
-```
-
-This will start executing a pytest suite containing hundreds of tests,
-but will skip the tests that require the `puf.csv` file or the `tmd.csv`
-file as input.
-
-**HAVE PUF AND HAVE TMD**: If you do have access to the PUF-related
-files and the TMD-related files, copy them into the Tax-Calculator
-directory at the top of the repository directory tree (but **never**
-add them to your repository) and run the second-phase of testing as
-follows at the command prompt in the Tax-Calculator directory:
-
-```
-make pytest-all
-make idtest
-```
-
-The first command will start executing a pytest suite containing
-hundreds of tests, including the tests that require the `puf.csv` file
-as input and the tests that require the `tmd.csv` file as input.  The
-second command checks that the Tax-Calculator CLI generates expected
-results when using the CPS, PUF, and TMD input data.
+No messages indicate the tests pass.
 
 ## Interpreting test results
 

--- a/taxcalc/structural-enhancement.md
+++ b/taxcalc/structural-enhancement.md
@@ -74,7 +74,7 @@ they all pass.  If a test command fails, return to step 3 revising
 changes until all tests pass.  These tests should all pass because a
 structural enhancment **adds** capabilities; it does not change how
 taxes are calculated under current-law policy or under the reforms that
-are already parameterized.  The order matters: the pytest-all command
+are already parameterized.  The order matters: the pytest command
 uninstalls the local taxcalc package that the brtest and idtest
 commands build and install.  Because they build and install the
 package, the brtest and idtest commands take considerably longer than
@@ -82,7 +82,7 @@ the other commands.
 
 - Execute the "make cstest > rescs 2>&1" command
   * Test fails if the rescs file is not empty
-- Execute the "make pytest-all > respy 2>&1 ; echo EXIT=$?" command
+- Execute the "make pytest > respy 2>&1 ; echo EXIT=$?" command
   * Test fails if the EXIT value is not zero (consult the respy file to
     diagnose the failure; do not rely on the last line of respy alone,
     because collection errors and crashes are reported differently from
@@ -96,7 +96,7 @@ the other commands.
     error and traceback patterns, as well as the differ pattern, guards
     against a test that appears to pass only because it never ran
 
-The brtest and idtest commands, and some of the pytest-all tests,
+The brtest and idtest commands, and some of the pytest tests,
 compare results against stored expected results.  When such a
 comparison fails, the difference indicates a bug in the branch changes
 that must be fixed in step 3.  Never revise a test, or a file
@@ -109,7 +109,7 @@ STEP 5: ASK IF SHOULD COMMIT CHANGES
           committed
 - Action: check "git status" for stray test output files, such as
           df-??-#-* files, which are left behind when a failing
-          pytest-all command aborts before the Makefile pytest-cleanup
+          pytest command aborts before the Makefile pytest-cleanup
           step runs
 - Action: ask if should commit changes or leave that up to the user.
 - Action: do not push the branch to GitHub and do not open a pull request;

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -8,6 +8,7 @@ Test Records class and its methods.
 import os
 import json
 from io import StringIO
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
@@ -346,6 +347,9 @@ def test_puf_availability(tests_path, puf_data_path):
     """
     Cross-check records_variables.json data with variables in puf.csv file
     """
+    # skip test if puf.csv is not available
+    if not Path(puf_data_path).exists():
+        return
     # make set of variable names that are in the puf.csv file
     pufdf = pd.read_csv(puf_data_path)
     pufvars = set(sorted(list(pufdf)))
@@ -367,6 +371,9 @@ def test_tmd_availability(tests_path, tmd_data_path):
     """
     Cross-check records_variables.json data with variables in tmd.csv file
     """
+    # skip test if tmd.csv is not available
+    if not Path(tmd_data_path).exists():
+        return
     # make set of variable names that are in the tmd.csv file
     tmddf = pd.read_csv(tmd_data_path)
     tmdvars = set(sorted(list(tmddf)))


### PR DESCRIPTION
Now there is just one comprehensive unit tests target: "make pytest"

Also, added a compound target: "make tests" that invokes cstest, pytest, brtest, and idtest, in that order.
